### PR TITLE
Add steps for Terms and Conditions page, which included the initial setup of Wiremock.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -54,6 +54,7 @@ dependencies {
     testImplementation "io.cucumber:cucumber-java:${cucumberVersion}"
     testImplementation "io.cucumber:cucumber-spring:${cucumberVersion}"
     testImplementation "org.assertj:assertj-core:3.13.2"
+    testImplementation "com.github.tomakehurst:wiremock-jre8:2.24.1"
 }
 
 test {

--- a/src/test/java/uk/gov/dhsc/htbhf/CucumberConfiguration.java
+++ b/src/test/java/uk/gov/dhsc/htbhf/CucumberConfiguration.java
@@ -1,5 +1,7 @@
 package uk.gov.dhsc.htbhf;
 
+import com.github.tomakehurst.wiremock.WireMockServer;
+import com.github.tomakehurst.wiremock.client.WireMock;
 import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.chrome.ChromeDriver;
 import org.openqa.selenium.chrome.ChromeOptions;
@@ -10,6 +12,9 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.PropertySource;
+import uk.gov.dhsc.htbhf.utils.WireMockManager;
+
+import static com.github.tomakehurst.wiremock.core.WireMockConfiguration.wireMockConfig;
 
 @Configuration
 @PropertySource("classpath:application.properties")
@@ -37,6 +42,20 @@ public class CucumberConfiguration {
     @Bean
     public WebDriverWait webDriverWait(WebDriver webDriver, @Value("${wait.timeout.seconds}") int waitTimeoutInSeconds) {
         return new WebDriverWait(webDriver, waitTimeoutInSeconds);
+    }
+
+    @Bean(destroyMethod = "stop")
+    public WireMockServer wireMockServer(@Value("${wiremock.port}") int wiremockPort) {
+        WireMockServer wireMockServer = new WireMockServer(wireMockConfig().port(wiremockPort));
+        wireMockServer.start();
+        //Configure the WireMock client to use the same port configured for the server.
+        WireMock.configureFor(wiremockPort);
+        return wireMockServer;
+    }
+
+    @Bean
+    public WireMockManager wireMockManager(WireMockServer wireMockServer) {
+        return new WireMockManager(wireMockServer);
     }
 
 }

--- a/src/test/java/uk/gov/dhsc/htbhf/page/ConfirmationPage.java
+++ b/src/test/java/uk/gov/dhsc/htbhf/page/ConfirmationPage.java
@@ -1,0 +1,29 @@
+package uk.gov.dhsc.htbhf.page;
+
+import org.openqa.selenium.WebDriver;
+import org.openqa.selenium.support.ui.WebDriverWait;
+
+/**
+ * Page object for the confirmation page.
+ */
+public class ConfirmationPage extends BasePage {
+
+    public ConfirmationPage(WebDriver webDriver, String baseUrl, WebDriverWait wait) {
+        super(webDriver, baseUrl, wait);
+    }
+
+    @Override
+    String getPath() {
+        return "/confirm";
+    }
+
+    @Override
+    String getPageName() {
+        return "confirmation";
+    }
+
+    @Override
+    String getPageTitle() {
+        return "GOV.UK - Application complete";
+    }
+}

--- a/src/test/java/uk/gov/dhsc/htbhf/page/TermsAndConditionsPage.java
+++ b/src/test/java/uk/gov/dhsc/htbhf/page/TermsAndConditionsPage.java
@@ -1,0 +1,38 @@
+package uk.gov.dhsc.htbhf.page;
+
+import org.openqa.selenium.By;
+import org.openqa.selenium.WebDriver;
+import org.openqa.selenium.WebElement;
+import org.openqa.selenium.support.ui.WebDriverWait;
+
+/**
+ * Page object representing the T's and C's page.
+ */
+public class TermsAndConditionsPage extends SubmittablePage {
+
+    public TermsAndConditionsPage(WebDriver webDriver, String baseUrl, WebDriverWait wait) {
+        super(webDriver, baseUrl, wait);
+    }
+
+    @Override
+    String getPath() {
+        return "/terms-and-conditions";
+    }
+
+    @Override
+    String getPageName() {
+        return "terms and conditions";
+    }
+
+    @Override
+    String getPageTitle() {
+        return "GOV.UK - Terms and conditions";
+    }
+
+    public void clickAcceptTermsAndConditionsCheckBox() {
+        WebElement checkbox = findByCss("input[value=\"agree\"]");
+        WebElement parentDiv = checkbox.findElement(By.xpath(".."));
+        WebElement label = parentDiv.findElement(By.className("govuk-checkboxes__label"));
+        label.click();
+    }
+}

--- a/src/test/java/uk/gov/dhsc/htbhf/steps/BaseSteps.java
+++ b/src/test/java/uk/gov/dhsc/htbhf/steps/BaseSteps.java
@@ -4,6 +4,7 @@ import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.support.ui.WebDriverWait;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
+import uk.gov.dhsc.htbhf.utils.WireMockManager;
 
 /**
  * Base setup for all the step classes which autowires in the web driver and anything
@@ -17,6 +18,9 @@ public abstract class BaseSteps {
 
     @Autowired
     protected WebDriverWait webDriverWait;
+
+    @Autowired
+    protected WireMockManager wireMockManager;
 
     @Value("${base.url}")
     protected String baseUrl;

--- a/src/test/java/uk/gov/dhsc/htbhf/steps/TermsAndConditionsSteps.java
+++ b/src/test/java/uk/gov/dhsc/htbhf/steps/TermsAndConditionsSteps.java
@@ -1,0 +1,31 @@
+package uk.gov.dhsc.htbhf.steps;
+
+import io.cucumber.java.en.When;
+import uk.gov.dhsc.htbhf.page.CheckDetailsPage;
+import uk.gov.dhsc.htbhf.page.ConfirmationPage;
+import uk.gov.dhsc.htbhf.page.TermsAndConditionsPage;
+
+public class TermsAndConditionsSteps extends BaseSteps {
+
+    private CheckDetailsPage checkDetailsPage;
+    private TermsAndConditionsPage termsAndConditionsPage;
+    private ConfirmationPage confirmationPage;
+
+    @When("/^I accept the terms and conditions and submit my application$/")
+    public void acceptTermsAndConditionsAndSubmitApplication() {
+        wireMockManager.setupWireMockMappingsWithStatus("ELIGIBLE");
+        checkDetailsPage = new CheckDetailsPage(webDriver, baseUrl, webDriverWait);
+        checkDetailsPage.clickContinue();
+        acceptTsAndCsAndSubmitApplication();
+        confirmationPage = new ConfirmationPage(webDriver, baseUrl, webDriverWait);
+        confirmationPage.waitForPageToLoad();
+    }
+
+    private void acceptTsAndCsAndSubmitApplication() {
+        termsAndConditionsPage = new TermsAndConditionsPage(webDriver, baseUrl, webDriverWait);
+        termsAndConditionsPage.waitForPageToLoad();
+        termsAndConditionsPage.clickAcceptTermsAndConditionsCheckBox();
+        termsAndConditionsPage.clickContinue();
+    }
+
+}

--- a/src/test/java/uk/gov/dhsc/htbhf/utils/WireMockManager.java
+++ b/src/test/java/uk/gov/dhsc/htbhf/utils/WireMockManager.java
@@ -1,0 +1,60 @@
+package uk.gov.dhsc.htbhf.utils;
+
+import com.github.tomakehurst.wiremock.WireMockServer;
+
+import java.util.Map;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.*;
+import static uk.gov.dhsc.htbhf.utils.WiremockResponseTestDataFactory.aValidClaimResponseWithVoucherEntitlement;
+import static uk.gov.dhsc.htbhf.utils.WiremockResponseTestDataFactory.aValidClaimResponseWithoutVoucherEntitlement;
+
+/**
+ * Manages all interaction with wiremock
+ */
+public class WireMockManager {
+
+    public static final String CLAIMS_ENDPOINT = "/v2/claims";
+    public static final String REQUEST_ID_HEADER = "X-Request-ID";
+    public static final String SESSION_ID_HEADER = "X-Session-ID";
+    public static final String ID_HEADERS_REGEX = "([A-Za-z0-9_-])+";
+
+    private Map<String, Integer> ELIGIBILITY_RESPONSE_MAPPINGS = Map.of(
+            "ELIGIBLE", 201,
+            "INELIGIBLE", 200,
+            "PENDING", 200,
+            "NO_MATCH", 404,
+            "ERROR", 200,
+            "DUPLICATE", 200
+    );
+
+    private WireMockServer wireMockServer;
+
+    public WireMockManager(WireMockServer wireMockServer) {
+        this.wireMockServer = wireMockServer;
+    }
+
+    public void startWireMock() {
+        wireMockServer.start();
+    }
+
+    public void stopWireMock() {
+        wireMockServer.stop();
+    }
+
+    public void resetWireMockStubs() {
+        wireMockServer.resetAll();
+    }
+
+    public void setupWireMockMappingsWithStatus(String eligibilityStatus) {
+        String wireMockBody = (eligibilityStatus.equals("ELIGIBLE") ?
+                aValidClaimResponseWithVoucherEntitlement(eligibilityStatus) : aValidClaimResponseWithoutVoucherEntitlement(eligibilityStatus));
+        System.out.println("Wiremock body: " + wireMockBody);
+        stubFor(post(urlEqualTo(CLAIMS_ENDPOINT))
+                .withHeader(REQUEST_ID_HEADER, matching(ID_HEADERS_REGEX))
+                .withHeader(SESSION_ID_HEADER, matching(ID_HEADERS_REGEX))
+                .willReturn(aResponse()
+                        .withStatus(ELIGIBILITY_RESPONSE_MAPPINGS.get(eligibilityStatus))
+                        .withHeader("Content-Type", "application/json")
+                        .withBody(wireMockBody)));
+    }
+}

--- a/src/test/java/uk/gov/dhsc/htbhf/utils/WiremockResponseTestDataFactory.java
+++ b/src/test/java/uk/gov/dhsc/htbhf/utils/WiremockResponseTestDataFactory.java
@@ -1,0 +1,30 @@
+package uk.gov.dhsc.htbhf.utils;
+
+/**
+ * Factory for test data coming back from WireMock imitating the ClaimantService.
+ */
+public class WiremockResponseTestDataFactory {
+
+    public static String aValidClaimResponseWithVoucherEntitlement(String eligibilityStatus) {
+        return "{\"claimStatus\": \"NEW\", " +
+                "\"eligibilityStatus\": \"" + eligibilityStatus + "\", " +
+                "\"voucherEntitlement\": " + aValidVoucherEntitlement() +
+                "}";
+    }
+
+    public static String aValidClaimResponseWithoutVoucherEntitlement(String eligibilityStatus) {
+        return "{\"claimStatus\": \"NEW\"," +
+                "\"eligibilityStatus\": \"" + eligibilityStatus + "\"" +
+                "}";
+    }
+
+    public static String aValidVoucherEntitlement() {
+        return "{\"vouchersForChildrenUnderOne\": 2, " +
+                "\"vouchersForChildrenBetweenOneAndFour\": 1, " +
+                "\"vouchersForPregnancy\": 1, " +
+                "\"totalVoucherEntitlement\": 4, " +
+                "\"singleVoucherValueInPence\": 310, " +
+                "\"totalVoucherValueInPence\": 1240" +
+                "}";
+    }
+}

--- a/src/test/resources/application.properties
+++ b/src/test/resources/application.properties
@@ -3,3 +3,4 @@ base.url=http://localhost:8080
 wait.timeout.seconds=15
 test.headless=true
 session.details.url=http://localhost:8081/session-details/confirmation-code
+wiremock.port=8090

--- a/src/test/resources/apply-success.feature
+++ b/src/test/resources/apply-success.feature
@@ -7,6 +7,6 @@ Feature: Complete application journey
     Given I am on the first page of the application
     When I complete the application with valid details for a pregnant woman
     Then I am shown the check details page with correct page content
-#    And I accept the terms and conditions and submit my application
+    And I accept the terms and conditions and submit my application
 #    And I am shown a successful confirmation page
 #    And my entitlement is 12.40 per week with a first payment of 49.60


### PR DESCRIPTION
 - Add page object for Ts and Cs page mostly for the check box.
 - Add initial setup of WireMock which will be setup on localhost on start of the Cucumber tests on localhost:8090
 - Initial WireMock stubs are written as Strings for simplicity and to avoid a duplicate set of model objects in here, but if this proves unwieldy then we can add model object and use Jackson to build the JSON.