### PR TITLE
First attempt at splitting the configuration into two profile so we can…

### DIFF
--- a/src/test/java/uk/gov/dhsc/htbhf/BrowserStackConfiguration.java
+++ b/src/test/java/uk/gov/dhsc/htbhf/BrowserStackConfiguration.java
@@ -1,0 +1,43 @@
+package uk.gov.dhsc.htbhf;
+
+import org.openqa.selenium.WebDriver;
+import org.openqa.selenium.remote.DesiredCapabilities;
+import org.openqa.selenium.remote.RemoteWebDriver;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Profile;
+import org.springframework.context.annotation.PropertySource;
+import uk.gov.dhsc.htbhf.utils.NoopWireMockManager;
+import uk.gov.dhsc.htbhf.utils.WireMockManager;
+
+import java.net.MalformedURLException;
+import java.net.URL;
+
+@Configuration
+@PropertySource("classpath:application-browserstack.properties")
+@Profile("browserstack")
+public class BrowserStackConfiguration {
+
+    @Bean(destroyMethod = "close")
+    public WebDriver browserStackWebDriver() throws MalformedURLException {
+        //TODO MRS 2019-08-14: Import via config all these values
+        String BROWSER_STACK_USER = "";
+        String BROWSER_STACK_KEY = "";
+        String url = "https://hub-cloud.browserstack.com/wd/hub";
+        DesiredCapabilities caps = new DesiredCapabilities();
+        caps.setCapability("browserName", "iPhone");
+        caps.setCapability("device", "iPhone 8 Plus");
+        caps.setCapability("realMobile", "true");
+        caps.setCapability("os_version", "11");
+        caps.setCapability("browserstack.user", BROWSER_STACK_USER);
+        caps.setCapability("browserstack.key", BROWSER_STACK_KEY);
+        caps.setCapability("browserstack.use_w3c", "11");
+
+        return new RemoteWebDriver(new URL(url), caps);
+    }
+
+    @Bean
+    public WireMockManager noopWireMockManager() {
+        return new NoopWireMockManager();
+    }
+}

--- a/src/test/java/uk/gov/dhsc/htbhf/CucumberConfiguration.java
+++ b/src/test/java/uk/gov/dhsc/htbhf/CucumberConfiguration.java
@@ -1,61 +1,20 @@
 package uk.gov.dhsc.htbhf;
 
-import com.github.tomakehurst.wiremock.WireMockServer;
-import com.github.tomakehurst.wiremock.client.WireMock;
 import org.openqa.selenium.WebDriver;
-import org.openqa.selenium.chrome.ChromeDriver;
-import org.openqa.selenium.chrome.ChromeOptions;
-import org.openqa.selenium.firefox.FirefoxDriver;
-import org.openqa.selenium.firefox.FirefoxOptions;
 import org.openqa.selenium.support.ui.WebDriverWait;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Import;
 import org.springframework.context.annotation.PropertySource;
-import uk.gov.dhsc.htbhf.utils.WireMockManager;
-
-import static com.github.tomakehurst.wiremock.core.WireMockConfiguration.wireMockConfig;
 
 @Configuration
 @PropertySource("classpath:application.properties")
+@Import(value = {LocalConfiguration.class, BrowserStackConfiguration.class})
 public class CucumberConfiguration {
-
-    @Bean(destroyMethod = "close")
-    public WebDriver webDriver(@Value("${test.browser}") String browser, @Value("${test.headless}") boolean headless) {
-        WebDriver webdriver = null;
-        switch (browser) {
-            case "firefox":
-                FirefoxOptions firefoxOptions = new FirefoxOptions();
-                firefoxOptions.setHeadless(headless);
-                webdriver = new FirefoxDriver(firefoxOptions);
-                break;
-
-            case "chrome":
-                ChromeOptions chromeOptions = new ChromeOptions();
-                chromeOptions.setHeadless(headless);
-                webdriver = new ChromeDriver(chromeOptions);
-                break;
-        }
-        return webdriver;
-    }
-
     @Bean
     public WebDriverWait webDriverWait(WebDriver webDriver, @Value("${wait.timeout.seconds}") int waitTimeoutInSeconds) {
         return new WebDriverWait(webDriver, waitTimeoutInSeconds);
-    }
-
-    @Bean(destroyMethod = "stop")
-    public WireMockServer wireMockServer(@Value("${wiremock.port}") int wiremockPort) {
-        WireMockServer wireMockServer = new WireMockServer(wireMockConfig().port(wiremockPort));
-        wireMockServer.start();
-        //Configure the WireMock client to use the same port configured for the server.
-        WireMock.configureFor(wiremockPort);
-        return wireMockServer;
-    }
-
-    @Bean
-    public WireMockManager wireMockManager(WireMockServer wireMockServer) {
-        return new WireMockManager(wireMockServer);
     }
 
 }

--- a/src/test/java/uk/gov/dhsc/htbhf/LocalConfiguration.java
+++ b/src/test/java/uk/gov/dhsc/htbhf/LocalConfiguration.java
@@ -19,7 +19,7 @@ import static com.github.tomakehurst.wiremock.core.WireMockConfiguration.wireMoc
 
 @Configuration
 @PropertySource("classpath:application-local.properties")
-@Profile("local")
+@Profile("!browserstack")
 public class LocalConfiguration {
 
     @Bean(destroyMethod = "close")

--- a/src/test/java/uk/gov/dhsc/htbhf/LocalConfiguration.java
+++ b/src/test/java/uk/gov/dhsc/htbhf/LocalConfiguration.java
@@ -1,0 +1,57 @@
+package uk.gov.dhsc.htbhf;
+
+import com.github.tomakehurst.wiremock.WireMockServer;
+import com.github.tomakehurst.wiremock.client.WireMock;
+import org.openqa.selenium.WebDriver;
+import org.openqa.selenium.chrome.ChromeDriver;
+import org.openqa.selenium.chrome.ChromeOptions;
+import org.openqa.selenium.firefox.FirefoxDriver;
+import org.openqa.selenium.firefox.FirefoxOptions;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Profile;
+import org.springframework.context.annotation.PropertySource;
+import uk.gov.dhsc.htbhf.utils.WireMockManager;
+import uk.gov.dhsc.htbhf.utils.WireMockManagerImpl;
+
+import static com.github.tomakehurst.wiremock.core.WireMockConfiguration.wireMockConfig;
+
+@Configuration
+@PropertySource("classpath:application-local.properties")
+@Profile("local")
+public class LocalConfiguration {
+
+    @Bean(destroyMethod = "close")
+    public WebDriver localWebDriver(@Value("${test.browser}") String browser, @Value("${test.headless}") boolean headless) {
+        WebDriver webdriver = null;
+        switch (browser) {
+            case "firefox":
+                FirefoxOptions firefoxOptions = new FirefoxOptions();
+                firefoxOptions.setHeadless(headless);
+                webdriver = new FirefoxDriver(firefoxOptions);
+                break;
+
+            case "chrome":
+                ChromeOptions chromeOptions = new ChromeOptions();
+                chromeOptions.setHeadless(headless);
+                webdriver = new ChromeDriver(chromeOptions);
+                break;
+        }
+        return webdriver;
+    }
+
+    @Bean(destroyMethod = "stop")
+    public WireMockServer wireMockServer(@Value("${wiremock.port}") int wiremockPort) {
+        WireMockServer wireMockServer = new WireMockServer(wireMockConfig().port(wiremockPort));
+        wireMockServer.start();
+        //Configure the WireMock client to use the same port configured for the server.
+        WireMock.configureFor(wiremockPort);
+        return wireMockServer;
+    }
+
+    @Bean
+    public WireMockManager wireMockManagerImpl(WireMockServer wireMockServer) {
+        return new WireMockManagerImpl(wireMockServer);
+    }
+}

--- a/src/test/java/uk/gov/dhsc/htbhf/RunCucumberTest.java
+++ b/src/test/java/uk/gov/dhsc/htbhf/RunCucumberTest.java
@@ -8,6 +8,8 @@ import org.junit.runner.RunWith;
 @CucumberOptions(plugin = "pretty",
         features = "src/test/resources"
 )
+//TODO MRS 2019-08-14: Allow the configuration of properties (feature files) via config so we can have different feature files for BrowserStack.
+// Try this: https://stackoverflow.com/questions/45095557/java-cucumber-take-cucumberoptions-from-external-source-like-a-property-file
 public class RunCucumberTest {
 
 }

--- a/src/test/java/uk/gov/dhsc/htbhf/steps/BaseSteps.java
+++ b/src/test/java/uk/gov/dhsc/htbhf/steps/BaseSteps.java
@@ -28,4 +28,7 @@ public abstract class BaseSteps {
     @Value("${session.details.url}")
     protected String sessionDetailsUrl;
 
+    @Value("${spring.profiles.active}")
+    protected String activeProfile;
+
 }

--- a/src/test/java/uk/gov/dhsc/htbhf/steps/Hooks.java
+++ b/src/test/java/uk/gov/dhsc/htbhf/steps/Hooks.java
@@ -1,0 +1,16 @@
+package uk.gov.dhsc.htbhf.steps;
+
+import io.cucumber.java.After;
+
+public class Hooks extends BaseSteps {
+    @After
+    public void quitDriver() {
+        //TODO MRS 2019-08-14: Potentially need a property so that we quit the webdriver only after BrowserStack tests.
+        // Will also need to create a new WebDriver before each BrowserStack test.
+        if ("browserstack".equals(activeProfile)) {
+            System.out.println("Calling quit on WebDriver, active profile is: " + activeProfile);
+            //We need to always quit the WebDriver for BrowserStack tests.
+            webDriver.quit();
+        }
+    }
+}

--- a/src/test/java/uk/gov/dhsc/htbhf/utils/NoopWireMockManager.java
+++ b/src/test/java/uk/gov/dhsc/htbhf/utils/NoopWireMockManager.java
@@ -1,0 +1,8 @@
+package uk.gov.dhsc.htbhf.utils;
+
+/**
+ * Implementation of WireMockManager that does nothing which can be used for BrowserStack testing
+ * without having to have conditional logic in the steps.
+ */
+public class NoopWireMockManager implements WireMockManager {
+}

--- a/src/test/java/uk/gov/dhsc/htbhf/utils/WireMockManager.java
+++ b/src/test/java/uk/gov/dhsc/htbhf/utils/WireMockManager.java
@@ -1,59 +1,19 @@
 package uk.gov.dhsc.htbhf.utils;
 
-import com.github.tomakehurst.wiremock.WireMockServer;
-
-import java.util.Map;
-
-import static com.github.tomakehurst.wiremock.client.WireMock.*;
-import static uk.gov.dhsc.htbhf.utils.WiremockResponseTestDataFactory.aValidClaimResponseWithVoucherEntitlement;
-import static uk.gov.dhsc.htbhf.utils.WiremockResponseTestDataFactory.aValidClaimResponseWithoutVoucherEntitlement;
-
 /**
- * Manages all interaction with WireMock
+ * Interface for WireMock manager implementations so that we can have a No-op implementation
+ * as well as a full implementation so it can be swapped out when using BrowserStack.
  */
-public class WireMockManager {
-
-    private static final String CLAIMS_ENDPOINT = "/v2/claims";
-    private static final String REQUEST_ID_HEADER = "X-Request-ID";
-    private static final String SESSION_ID_HEADER = "X-Session-ID";
-    private static final String ID_HEADERS_REGEX = "([A-Za-z0-9_-])+";
-
-    private Map<String, Integer> ELIGIBILITY_RESPONSE_MAPPINGS = Map.of(
-            "ELIGIBLE", 201,
-            "INELIGIBLE", 200,
-            "PENDING", 200,
-            "NO_MATCH", 404,
-            "ERROR", 200,
-            "DUPLICATE", 200
-    );
-
-    private WireMockServer wireMockServer;
-
-    public WireMockManager(WireMockServer wireMockServer) {
-        this.wireMockServer = wireMockServer;
+public interface WireMockManager {
+    default void startWireMock() {
     }
 
-    public void startWireMock() {
-        wireMockServer.start();
+    default void stopWireMock(){
     }
 
-    public void stopWireMock() {
-        wireMockServer.stop();
+    default void resetWireMockStubs(){
     }
 
-    public void resetWireMockStubs() {
-        wireMockServer.resetAll();
-    }
-
-    public void setupWireMockMappingsWithStatus(String eligibilityStatus) {
-        String wireMockBody = (eligibilityStatus.equals("ELIGIBLE") ?
-                aValidClaimResponseWithVoucherEntitlement(eligibilityStatus) : aValidClaimResponseWithoutVoucherEntitlement(eligibilityStatus));
-        stubFor(post(urlEqualTo(CLAIMS_ENDPOINT))
-                .withHeader(REQUEST_ID_HEADER, matching(ID_HEADERS_REGEX))
-                .withHeader(SESSION_ID_HEADER, matching(ID_HEADERS_REGEX))
-                .willReturn(aResponse()
-                        .withStatus(ELIGIBILITY_RESPONSE_MAPPINGS.get(eligibilityStatus))
-                        .withHeader("Content-Type", "application/json")
-                        .withBody(wireMockBody)));
+    default void setupWireMockMappingsWithStatus(String eligibilityStatus){
     }
 }

--- a/src/test/java/uk/gov/dhsc/htbhf/utils/WireMockManagerImpl.java
+++ b/src/test/java/uk/gov/dhsc/htbhf/utils/WireMockManagerImpl.java
@@ -1,0 +1,63 @@
+package uk.gov.dhsc.htbhf.utils;
+
+import com.github.tomakehurst.wiremock.WireMockServer;
+
+import java.util.Map;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.*;
+import static uk.gov.dhsc.htbhf.utils.WiremockResponseTestDataFactory.aValidClaimResponseWithVoucherEntitlement;
+import static uk.gov.dhsc.htbhf.utils.WiremockResponseTestDataFactory.aValidClaimResponseWithoutVoucherEntitlement;
+
+/**
+ * Manages all interactions with WireMock
+ */
+public class WireMockManagerImpl implements WireMockManager {
+
+    private static final String CLAIMS_ENDPOINT = "/v2/claims";
+    private static final String REQUEST_ID_HEADER = "X-Request-ID";
+    private static final String SESSION_ID_HEADER = "X-Session-ID";
+    private static final String ID_HEADERS_REGEX = "([A-Za-z0-9_-])+";
+
+    private Map<String, Integer> ELIGIBILITY_RESPONSE_MAPPINGS = Map.of(
+            "ELIGIBLE", 201,
+            "INELIGIBLE", 200,
+            "PENDING", 200,
+            "NO_MATCH", 404,
+            "ERROR", 200,
+            "DUPLICATE", 200
+    );
+
+    private WireMockServer wireMockServer;
+
+    public WireMockManagerImpl(WireMockServer wireMockServer) {
+        this.wireMockServer = wireMockServer;
+    }
+
+    @Override
+    public void startWireMock() {
+        wireMockServer.start();
+    }
+
+    @Override
+    public void stopWireMock() {
+        wireMockServer.stop();
+    }
+
+    @Override
+    public void resetWireMockStubs() {
+        wireMockServer.resetAll();
+    }
+
+    @Override
+    public void setupWireMockMappingsWithStatus(String eligibilityStatus) {
+        String wireMockBody = (eligibilityStatus.equals("ELIGIBLE") ?
+                aValidClaimResponseWithVoucherEntitlement(eligibilityStatus) : aValidClaimResponseWithoutVoucherEntitlement(eligibilityStatus));
+        stubFor(post(urlEqualTo(CLAIMS_ENDPOINT))
+                .withHeader(REQUEST_ID_HEADER, matching(ID_HEADERS_REGEX))
+                .withHeader(SESSION_ID_HEADER, matching(ID_HEADERS_REGEX))
+                .willReturn(aResponse()
+                        .withStatus(ELIGIBILITY_RESPONSE_MAPPINGS.get(eligibilityStatus))
+                        .withHeader("Content-Type", "application/json")
+                        .withBody(wireMockBody)));
+    }
+}

--- a/src/test/resources/application-browserstack.properties
+++ b/src/test/resources/application-browserstack.properties
@@ -1,0 +1,2 @@
+base.url=https://help-to-buy-healthy-foods-staging.london.cloudapps.digital
+session.details.url=https://help-to-buy-healthy-foods-staging.london.cloudapps.digital/session-details/confirmation-code

--- a/src/test/resources/application-local.properties
+++ b/src/test/resources/application-local.properties
@@ -1,0 +1,5 @@
+test.browser=chrome
+base.url=http://localhost:8080
+test.headless=true
+session.details.url=http://localhost:8081/session-details/confirmation-code
+wiremock.port=8090

--- a/src/test/resources/application.properties
+++ b/src/test/resources/application.properties
@@ -1,6 +1,2 @@
-test.browser=chrome
-base.url=http://localhost:8080
 wait.timeout.seconds=15
-test.headless=true
-session.details.url=http://localhost:8081/session-details/confirmation-code
-wiremock.port=8090
+spring.profiles.active=local

--- a/src/test/resources/application.properties
+++ b/src/test/resources/application.properties
@@ -1,2 +1,2 @@
 wait.timeout.seconds=15
-spring.profiles.active=local
+spring.profiles.active=


### PR DESCRIPTION
… configure different beans and config for BrowserStack.

This is a bit of a work in progress PR, not sure if I'll merge it but wanted to get it out for comments and review. Have done:

 - introduce two Configuration classes based on local or BrowserStack profiles which have different web drivers and configuration.
 - added a WireMockManager interface so that we could have a No-Op implementation when running BrowserStack tests. I thought this was better than a boolean being thrown around.

Still to do:
 - Pass in the BrowserStack options so we can test different OS and browser options.
 - Make the set of feature files to run for the tests be configurable
 - Find a nicer way to only call webdriver.quit() for BrowserStack tests (we might also need to rebuild a new WebDriver each time too).
 - Run multiple tests for different configurations for BrowserStack tests
 - Add retry capability
 - Only allow a subset of tests to run so we don't try to run too many at once and BrowserStack reject them.

There's probably more but that's a bit of a brain dump (plus also why I wanted to get an initial PR up).