### PR TITLE
Modify the construction of WebDriver and WebDriverWait so that we are…

### DIFF
--- a/src/test/java/uk/gov/dhsc/htbhf/BrowserStackConfiguration.java
+++ b/src/test/java/uk/gov/dhsc/htbhf/BrowserStackConfiguration.java
@@ -1,9 +1,6 @@
 package uk.gov.dhsc.htbhf;
 
 import lombok.extern.slf4j.Slf4j;
-import org.apache.commons.lang3.Validate;
-import org.openqa.selenium.WebDriver;
-import org.openqa.selenium.remote.RemoteWebDriver;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -12,20 +9,11 @@ import org.springframework.context.annotation.PropertySource;
 import uk.gov.dhsc.htbhf.utils.NoopWireMockManager;
 import uk.gov.dhsc.htbhf.utils.WireMockManager;
 
-import java.net.MalformedURLException;
-import java.net.URL;
-import java.util.Map;
-
-import static uk.gov.dhsc.htbhf.BrowserStackCapabilities.buildDesiredCapabilities;
-import static uk.gov.dhsc.htbhf.BrowserStackCapabilities.getBrowserStackCapabilities;
-
 @Configuration
 @PropertySource("classpath:application-browserstack.properties")
 @Profile("browserstack")
 @Slf4j
 public class BrowserStackConfiguration {
-
-    private static final String BROWSER_STACK_URL = "https://hub-cloud.browserstack.com/wd/hub";
 
     @Value("${BROWSER_STACK_USER:}")
     private String browserStackUser;
@@ -33,15 +21,12 @@ public class BrowserStackConfiguration {
     @Value("${BROWSER_STACK_KEY:}")
     private String browserStackKey;
 
-    @Bean(destroyMethod = "close")
-    public WebDriver browserStackWebDriver() throws MalformedURLException {
-        Validate.notBlank(browserStackUser, "BrowserStack user must be provided, set the BROWSER_STACK_USER environment variable");
-        Validate.notBlank(browserStackKey, "BrowserStack key must be provided, set the BROWSER_STACK_KEY environment variable");
-        log.info("Using login: {} {}", browserStackUser, browserStackKey);
-        Map<String, String> browserStackCapabilities = getBrowserStackCapabilities(System.getProperties());
-        log.info("Using capabilities: {}", browserStackCapabilities);
+    @Value("${wait.timeout.seconds}")
+    private int waitTimeoutInSeconds;
 
-        return new RemoteWebDriver(new URL(BROWSER_STACK_URL), buildDesiredCapabilities(browserStackCapabilities, browserStackUser, browserStackKey));
+    @Bean(destroyMethod = "closeDriver")
+    public WebDriverWrapper browserStackDriverBuilder() {
+        return new BrowserStackDriverWrapper(browserStackUser, browserStackKey, waitTimeoutInSeconds);
     }
 
     @Bean

--- a/src/test/java/uk/gov/dhsc/htbhf/BrowserStackDriverWrapper.java
+++ b/src/test/java/uk/gov/dhsc/htbhf/BrowserStackDriverWrapper.java
@@ -1,0 +1,88 @@
+package uk.gov.dhsc.htbhf;
+
+import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.lang3.Validate;
+import org.openqa.selenium.WebDriver;
+import org.openqa.selenium.remote.DesiredCapabilities;
+import org.openqa.selenium.remote.RemoteWebDriver;
+import org.openqa.selenium.support.ui.WebDriverWait;
+
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.util.Map;
+
+import static uk.gov.dhsc.htbhf.BrowserStackCapabilities.buildDesiredCapabilities;
+import static uk.gov.dhsc.htbhf.BrowserStackCapabilities.getBrowserStackCapabilities;
+
+/**
+ * Controls building of the WebDriver and WebDriverWait needed for BrowserStack testing so that we can rebuild them when required.
+ */
+@Slf4j
+public class BrowserStackDriverWrapper implements WebDriverWrapper {
+
+    private static final String BROWSER_STACK_URL = "https://hub-cloud.browserstack.com/wd/hub";
+
+    private final int waitTimeoutInSeconds;
+
+    private final DesiredCapabilities desiredCapabilities;
+
+    private final URL browserStackUrl;
+
+    private WebDriver webDriver;
+
+    private WebDriverWait webDriverWait;
+
+    public BrowserStackDriverWrapper(String browserStackUser, String browserStackKey, int waitTimeoutInSeconds) {
+        Validate.notBlank(browserStackUser, "BrowserStack user must be provided, set the BROWSER_STACK_USER environment variable");
+        Validate.notBlank(browserStackKey, "BrowserStack key must be provided, set the BROWSER_STACK_KEY environment variable");
+        log.info("Using login: {} {}", browserStackUser, browserStackKey);
+        this.waitTimeoutInSeconds = waitTimeoutInSeconds;
+        Map<String, String> browserStackCapabilities = getBrowserStackCapabilities(System.getProperties());
+        log.info("Using capabilities: {}", browserStackCapabilities);
+        this.desiredCapabilities = buildDesiredCapabilities(browserStackCapabilities, browserStackUser, browserStackKey);
+        this.browserStackUrl = buildBrowserStackUrl();
+    }
+
+    @Override
+    public WebDriver getWebDriver() {
+        return webDriver;
+    }
+
+    @Override
+    public WebDriverWait getWebDriverWait() {
+        return webDriverWait;
+    }
+
+    @Override
+    public void initDriver() {
+        this.webDriver = buildWebDriver();
+        this.webDriverWait = buildWebDriverWait();
+    }
+
+    @Override
+    public void quitDriver() {
+        webDriver.quit();
+    }
+
+    @Override
+    public void closeDriver() {
+        webDriver.close();
+    }
+
+    //Simply to deal with the checked Exception
+    private URL buildBrowserStackUrl() {
+        try {
+            return new URL(BROWSER_STACK_URL);
+        } catch (MalformedURLException e) {
+            throw new RuntimeException("Unable to build BrowserStack URL", e);
+        }
+    }
+
+    private WebDriverWait buildWebDriverWait() {
+        return new WebDriverWait(webDriver, waitTimeoutInSeconds);
+    }
+
+    private RemoteWebDriver buildWebDriver() {
+        return new RemoteWebDriver(browserStackUrl, desiredCapabilities);
+    }
+}

--- a/src/test/java/uk/gov/dhsc/htbhf/CucumberConfiguration.java
+++ b/src/test/java/uk/gov/dhsc/htbhf/CucumberConfiguration.java
@@ -1,9 +1,5 @@
 package uk.gov.dhsc.htbhf;
 
-import org.openqa.selenium.WebDriver;
-import org.openqa.selenium.support.ui.WebDriverWait;
-import org.springframework.beans.factory.annotation.Value;
-import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Import;
 import org.springframework.context.annotation.PropertySource;
@@ -12,9 +8,5 @@ import org.springframework.context.annotation.PropertySource;
 @PropertySource("classpath:application.properties")
 @Import(value = {LocalConfiguration.class, BrowserStackConfiguration.class})
 public class CucumberConfiguration {
-    @Bean
-    public WebDriverWait webDriverWait(WebDriver webDriver, @Value("${wait.timeout.seconds}") int waitTimeoutInSeconds) {
-        return new WebDriverWait(webDriver, waitTimeoutInSeconds);
-    }
 
 }

--- a/src/test/java/uk/gov/dhsc/htbhf/LocalConfiguration.java
+++ b/src/test/java/uk/gov/dhsc/htbhf/LocalConfiguration.java
@@ -2,11 +2,6 @@ package uk.gov.dhsc.htbhf;
 
 import com.github.tomakehurst.wiremock.WireMockServer;
 import com.github.tomakehurst.wiremock.client.WireMock;
-import org.openqa.selenium.WebDriver;
-import org.openqa.selenium.chrome.ChromeDriver;
-import org.openqa.selenium.chrome.ChromeOptions;
-import org.openqa.selenium.firefox.FirefoxDriver;
-import org.openqa.selenium.firefox.FirefoxOptions;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -22,27 +17,25 @@ import static com.github.tomakehurst.wiremock.core.WireMockConfiguration.wireMoc
 @Profile("!browserstack")
 public class LocalConfiguration {
 
-    @Bean(destroyMethod = "close")
-    public WebDriver localWebDriver(@Value("${test.browser}") String browser, @Value("${test.headless}") boolean headless) {
-        WebDriver webdriver = null;
-        switch (browser) {
-            case "firefox":
-                FirefoxOptions firefoxOptions = new FirefoxOptions();
-                firefoxOptions.setHeadless(headless);
-                webdriver = new FirefoxDriver(firefoxOptions);
-                break;
+    @Value("${test.browser}")
+    private String browser;
 
-            case "chrome":
-                ChromeOptions chromeOptions = new ChromeOptions();
-                chromeOptions.setHeadless(headless);
-                webdriver = new ChromeDriver(chromeOptions);
-                break;
-        }
-        return webdriver;
+    @Value("${test.headless}")
+    private boolean headless;
+
+    @Value("${wait.timeout.seconds}")
+    private int waitTimeoutInSeconds;
+
+    @Value("${wiremock.port}")
+    private int wiremockPort;
+
+    @Bean(destroyMethod = "closeDriver")
+    public WebDriverWrapper localWebDriverWrapper() {
+        return new LocalWebDriverWrapper(browser, headless, waitTimeoutInSeconds);
     }
 
     @Bean(destroyMethod = "stop")
-    public WireMockServer wireMockServer(@Value("${wiremock.port}") int wiremockPort) {
+    public WireMockServer wireMockServer() {
         WireMockServer wireMockServer = new WireMockServer(wireMockConfig().port(wiremockPort));
         wireMockServer.start();
         //Configure the WireMock client to use the same port configured for the server.

--- a/src/test/java/uk/gov/dhsc/htbhf/LocalWebDriverWrapper.java
+++ b/src/test/java/uk/gov/dhsc/htbhf/LocalWebDriverWrapper.java
@@ -1,0 +1,76 @@
+package uk.gov.dhsc.htbhf;
+
+import org.openqa.selenium.WebDriver;
+import org.openqa.selenium.chrome.ChromeDriver;
+import org.openqa.selenium.chrome.ChromeOptions;
+import org.openqa.selenium.firefox.FirefoxDriver;
+import org.openqa.selenium.firefox.FirefoxOptions;
+import org.openqa.selenium.support.ui.WebDriverWait;
+
+/**
+ * Controls creation of WebDriver and WebDriverWait for local testing.
+ */
+public class LocalWebDriverWrapper implements WebDriverWrapper {
+
+    private final String browser;
+    private final boolean headless;
+    private final int waitTimeoutInSeconds;
+    private final WebDriver webDriver;
+    private final WebDriverWait webDriverWait;
+
+    public LocalWebDriverWrapper(String browser, boolean headless, int waitTimeoutInSeconds) {
+        this.browser = browser;
+        this.headless = headless;
+        this.waitTimeoutInSeconds = waitTimeoutInSeconds;
+        this.webDriver = buildWebDriver();
+        this.webDriverWait = buildWebDriverWait();
+    }
+
+    @Override
+    public WebDriver getWebDriver() {
+        return webDriver;
+    }
+
+    @Override
+    public WebDriverWait getWebDriverWait() {
+        return webDriverWait;
+    }
+
+    @Override
+    public void initDriver() {
+        throw new RuntimeException("This is for BrowserStack WebDrivers only");
+    }
+
+    @Override
+    public void quitDriver() {
+        throw new RuntimeException("Should not be calling quit() on a local WebDriver, this is for BrowserStack WebDrivers only");
+    }
+
+    @Override
+    public void closeDriver() {
+        webDriver.close();
+    }
+
+    private WebDriver buildWebDriver() {
+        WebDriver webdriver = null;
+        switch (browser) {
+            case "firefox":
+                FirefoxOptions firefoxOptions = new FirefoxOptions();
+                firefoxOptions.setHeadless(headless);
+                webdriver = new FirefoxDriver(firefoxOptions);
+                break;
+
+            case "chrome":
+                ChromeOptions chromeOptions = new ChromeOptions();
+                chromeOptions.setHeadless(headless);
+                webdriver = new ChromeDriver(chromeOptions);
+                break;
+        }
+        return webdriver;
+    }
+
+    private WebDriverWait buildWebDriverWait() {
+        return new WebDriverWait(webDriver, waitTimeoutInSeconds);
+    }
+
+}

--- a/src/test/java/uk/gov/dhsc/htbhf/WebDriverWrapper.java
+++ b/src/test/java/uk/gov/dhsc/htbhf/WebDriverWrapper.java
@@ -1,0 +1,21 @@
+package uk.gov.dhsc.htbhf;
+
+import org.openqa.selenium.WebDriver;
+import org.openqa.selenium.support.ui.WebDriverWait;
+
+/**
+ * Wraps the lifecycle of a WebDriver and WebDriverWait.
+ */
+public interface WebDriverWrapper {
+
+    WebDriver getWebDriver();
+
+    WebDriverWait getWebDriverWait();
+
+    void initDriver();
+
+    void quitDriver();
+
+    void closeDriver();
+
+}

--- a/src/test/java/uk/gov/dhsc/htbhf/steps/BaseSteps.java
+++ b/src/test/java/uk/gov/dhsc/htbhf/steps/BaseSteps.java
@@ -4,6 +4,7 @@ import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.support.ui.WebDriverWait;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
+import uk.gov.dhsc.htbhf.WebDriverWrapper;
 import uk.gov.dhsc.htbhf.utils.WireMockManager;
 
 /**
@@ -14,10 +15,7 @@ import uk.gov.dhsc.htbhf.utils.WireMockManager;
 public abstract class BaseSteps {
 
     @Autowired
-    protected WebDriver webDriver;
-
-    @Autowired
-    protected WebDriverWait webDriverWait;
+    protected WebDriverWrapper webDriverWrapper;
 
     @Autowired
     protected WireMockManager wireMockManager;
@@ -30,5 +28,13 @@ public abstract class BaseSteps {
 
     @Value("${spring.profiles.active}")
     protected String activeProfile;
+
+    protected WebDriver getWebDriver() {
+        return webDriverWrapper.getWebDriver();
+    }
+
+    protected WebDriverWait getWebDriverWait() {
+        return webDriverWrapper.getWebDriverWait();
+    }
 
 }

--- a/src/test/java/uk/gov/dhsc/htbhf/steps/CheckDetailsSteps.java
+++ b/src/test/java/uk/gov/dhsc/htbhf/steps/CheckDetailsSteps.java
@@ -18,7 +18,7 @@ public class CheckDetailsSteps extends BaseSteps {
 
     @Then("^I am shown the check details page with correct page content$")
     public void verifyCheckDetailsPageCorrect() {
-        checkDetailsPage = new CheckDetailsPage(webDriver, baseUrl, webDriverWait);
+        checkDetailsPage = new CheckDetailsPage(getWebDriver(), baseUrl, getWebDriverWait());
         checkDetailsPage.waitForPageToLoad();
         assertThat(checkDetailsPage.getH1Text())
                 .as("expected check page H1 text to not be empty")

--- a/src/test/java/uk/gov/dhsc/htbhf/steps/CompleteFlowSteps.java
+++ b/src/test/java/uk/gov/dhsc/htbhf/steps/CompleteFlowSteps.java
@@ -28,7 +28,7 @@ public class CompleteFlowSteps extends BaseSteps {
 
     @When("^I complete the application with valid details for a pregnant woman")
     public void completeTheApplicationAsAPregnantWoman() {
-        guidancePage = GuidancePage.buildApplyGuidancePage(webDriver, baseUrl, webDriverWait);
+        guidancePage = GuidancePage.buildApplyGuidancePage(getWebDriver(), baseUrl, getWebDriverWait());
         guidancePage.clickStartButton();
         enterDoYouLiveInScotlandNoAndSubmit();
         enterDateOfBirthAndSubmit();
@@ -45,9 +45,9 @@ public class CompleteFlowSteps extends BaseSteps {
     }
 
     private void enterConfirmationCodeAndSubmit() {
-        enterCodePage = new EnterCodePage(webDriver, baseUrl, webDriverWait);
+        enterCodePage = new EnterCodePage(getWebDriver(), baseUrl, getWebDriverWait());
         enterCodePage.waitForPageToLoad();
-        confirmationCodePage = new ConfirmationCodePage(webDriver, sessionDetailsUrl);
+        confirmationCodePage = new ConfirmationCodePage(getWebDriver(), sessionDetailsUrl);
         String confirmationCode = confirmationCodePage.getConfirmationCodeForSession();
         enterCodePage.open();
         enterCodePage.enterCode(confirmationCode);
@@ -55,28 +55,28 @@ public class CompleteFlowSteps extends BaseSteps {
     }
 
     private void selectTextOnSendCode() {
-        sendCodePage = new SendCodePage(webDriver, baseUrl, webDriverWait);
+        sendCodePage = new SendCodePage(getWebDriver(), baseUrl, getWebDriverWait());
         sendCodePage.waitForPageToLoad();
         sendCodePage.selectText();
         sendCodePage.clickContinue();
     }
 
     private void enterEmailAddress() {
-        emailAddressPage = new EmailAddressPage(webDriver, baseUrl, webDriverWait);
+        emailAddressPage = new EmailAddressPage(getWebDriver(), baseUrl, getWebDriverWait());
         emailAddressPage.waitForPageToLoad();
         emailAddressPage.enterEmailAddress(EMAIL_ADDRESS);
         emailAddressPage.clickContinue();
     }
 
     private void enterPhoneNumber() {
-        phoneNumberPage = new PhoneNumberPage(webDriver, baseUrl, webDriverWait);
+        phoneNumberPage = new PhoneNumberPage(getWebDriver(), baseUrl, getWebDriverWait());
         phoneNumberPage.waitForPageToLoad();
         phoneNumberPage.enterPhoneNumber(PHONE_NUMBER);
         phoneNumberPage.clickContinue();
     }
 
     private void enterManualAddress() {
-        manualAddressPage = new ManualAddressPage(webDriver, baseUrl, webDriverWait);
+        manualAddressPage = new ManualAddressPage(getWebDriver(), baseUrl, getWebDriverWait());
         manualAddressPage.enterAddressLine1(ADDRESS_LINE_1);
         manualAddressPage.enterAddressLine2(ADDRESS_LINE_2);
         manualAddressPage.enterTownOrCity(TOWN);
@@ -86,21 +86,21 @@ public class CompleteFlowSteps extends BaseSteps {
     }
 
     private void enterNino() {
-        enterNinoPage = new EnterNinoPage(webDriver, baseUrl, webDriverWait);
+        enterNinoPage = new EnterNinoPage(getWebDriver(), baseUrl, getWebDriverWait());
         enterNinoPage.waitForPageToLoad();
         enterNinoPage.enterNino(generateEligibleNino());
         enterNinoPage.clickContinue();
     }
 
     private void enterName() {
-        enterNamePage = new EnterNamePage(webDriver, baseUrl, webDriverWait);
+        enterNamePage = new EnterNamePage(getWebDriver(), baseUrl, getWebDriverWait());
         enterNamePage.waitForPageToLoad();
         enterNamePage.enterName(FIRST_NAME, LAST_NAME);
         enterNamePage.clickContinue();
     }
 
     private void selectYesOnPregnancyPage() {
-        areYouPregnantPage = new AreYouPregnantPage(webDriver, baseUrl, webDriverWait);
+        areYouPregnantPage = new AreYouPregnantPage(getWebDriver(), baseUrl, getWebDriverWait());
         areYouPregnantPage.waitForPageToLoad();
         areYouPregnantPage.selectYes();
         areYouPregnantPage.enterExpectedDeliveryDate(2);
@@ -108,7 +108,7 @@ public class CompleteFlowSteps extends BaseSteps {
     }
 
     private void enterTwoChildrensDatesOfBirth() {
-        enterChildrensDobPage = new EnterChildrensDobPage(webDriver, baseUrl, webDriverWait);
+        enterChildrensDobPage = new EnterChildrensDobPage(getWebDriver(), baseUrl, getWebDriverWait());
         enterChildrensDobPage.waitForPageToLoad();
         enterChildrensDobPage.enterChild3OrUnderDetails(1);
         enterChildrensDobPage.clickAddAnotherChild();
@@ -117,14 +117,14 @@ public class CompleteFlowSteps extends BaseSteps {
     }
 
     private void enterDoYouHaveChildrenYesAndSubmit() {
-        doYouHaveChildren = new DoYouHaveChildren(webDriver, baseUrl, webDriverWait);
+        doYouHaveChildren = new DoYouHaveChildren(getWebDriver(), baseUrl, getWebDriverWait());
         doYouHaveChildren.waitForPageToLoad();
         doYouHaveChildren.selectYesRadioButton();
         doYouHaveChildren.clickContinue();
     }
 
     private void enterDateOfBirthAndSubmit() {
-        enterDobPage = new EnterDobPage(webDriver, baseUrl, webDriverWait);
+        enterDobPage = new EnterDobPage(getWebDriver(), baseUrl, getWebDriverWait());
         enterDobPage.waitForPageToLoad();
         enterDobPage.getDayInputField().enterValue(DOB_DAY);
         enterDobPage.getMonthInputField().enterValue(DOB_MONTH);
@@ -133,7 +133,7 @@ public class CompleteFlowSteps extends BaseSteps {
     }
 
     private void enterDoYouLiveInScotlandNoAndSubmit() {
-        doYouLiveInScotlandPage = new DoYouLiveInScotlandPage(webDriver, baseUrl, webDriverWait);
+        doYouLiveInScotlandPage = new DoYouLiveInScotlandPage(getWebDriver(), baseUrl, getWebDriverWait());
         doYouLiveInScotlandPage.waitForPageToLoad();
         doYouLiveInScotlandPage.selectNoRadioButton();
         doYouLiveInScotlandPage.clickContinue();

--- a/src/test/java/uk/gov/dhsc/htbhf/steps/ConfirmDetailsSteps.java
+++ b/src/test/java/uk/gov/dhsc/htbhf/steps/ConfirmDetailsSteps.java
@@ -15,7 +15,7 @@ public class ConfirmDetailsSteps extends BaseSteps {
 
     @Then("/^I am shown a successful confirmation page$/")
     public void iAmShownASuccessfulConfirmationPage() {
-        confirmationPage = new ConfirmationPage(webDriver, baseUrl, webDriverWait);
+        confirmationPage = new ConfirmationPage(getWebDriver(), baseUrl, getWebDriverWait());
         confirmationPage.waitForPageToLoad();
         checkAllPageContentIsPresentAndCorrect();
         wireMockManager.resetWireMockStubs();

--- a/src/test/java/uk/gov/dhsc/htbhf/steps/GuidanceSteps.java
+++ b/src/test/java/uk/gov/dhsc/htbhf/steps/GuidanceSteps.java
@@ -19,13 +19,13 @@ public class GuidanceSteps extends BaseSteps {
 
     @Given("^I am on the first page of the application")
     public void givenIAmOnTheFirstPageOfTheApplication() {
-        guidancePage = GuidancePage.buildApplyGuidancePage(webDriver, baseUrl, webDriverWait);
+        guidancePage = GuidancePage.buildApplyGuidancePage(getWebDriver(), baseUrl, getWebDriverWait());
         guidancePage.open();
     }
 
     @When("^I open the (.*) guidance page$")
     public void openGuidancePage(String pageName) {
-        guidancePage = new GuidancePage(webDriver, baseUrl, webDriverWait, pageName);
+        guidancePage = new GuidancePage(getWebDriver(), baseUrl, getWebDriverWait(), pageName);
         guidancePage.open();
     }
 

--- a/src/test/java/uk/gov/dhsc/htbhf/steps/Hooks.java
+++ b/src/test/java/uk/gov/dhsc/htbhf/steps/Hooks.java
@@ -1,16 +1,25 @@
 package uk.gov.dhsc.htbhf.steps;
 
 import io.cucumber.java.After;
+import io.cucumber.java.Before;
 
 public class Hooks extends BaseSteps {
+
+    @Before
+    public void initDriver() {
+        if ("browserstack".equals(activeProfile)) {
+            webDriverWrapper.initDriver();
+        }
+    }
+
     @After
     public void quitDriver() {
         //TODO MRS 2019-08-14: Potentially need a property so that we quit the webdriver only after BrowserStack tests.
         // Will also need to create a new WebDriver before each BrowserStack test.
         if ("browserstack".equals(activeProfile)) {
             System.out.println("Calling quit on WebDriver, active profile is: " + activeProfile);
-            //We need to always quit the WebDriver for BrowserStack tests.
-            webDriver.quit();
+            //We need to always quit the WebDriver for BrowserStack tests so we need to rebuild one for the next test.
+            webDriverWrapper.quitDriver();
         }
     }
 }

--- a/src/test/java/uk/gov/dhsc/htbhf/steps/TermsAndConditionsSteps.java
+++ b/src/test/java/uk/gov/dhsc/htbhf/steps/TermsAndConditionsSteps.java
@@ -15,13 +15,13 @@ public class TermsAndConditionsSteps extends BaseSteps {
     @When("/^I accept the terms and conditions and submit my application$/")
     public void acceptTermsAndConditionsAndSubmitApplication() {
         wireMockManager.setupWireMockMappingsWithStatus("ELIGIBLE");
-        checkDetailsPage = new CheckDetailsPage(webDriver, baseUrl, webDriverWait);
+        checkDetailsPage = new CheckDetailsPage(getWebDriver(), baseUrl, getWebDriverWait());
         checkDetailsPage.clickContinue();
         acceptTsAndCsAndSubmitApplication();
     }
 
     private void acceptTsAndCsAndSubmitApplication() {
-        termsAndConditionsPage = new TermsAndConditionsPage(webDriver, baseUrl, webDriverWait);
+        termsAndConditionsPage = new TermsAndConditionsPage(getWebDriver(), baseUrl, getWebDriverWait());
         termsAndConditionsPage.waitForPageToLoad();
         termsAndConditionsPage.clickAcceptTermsAndConditionsCheckBox();
         termsAndConditionsPage.clickContinue();


### PR DESCRIPTION
… wrapping it and can then control its creation and closing for BrowserStack tests.

This is all in preparation for being able to run the Compatibility Tests directly via a test launcher in Java so that we can properly multi-thread the test runs and query the results ourselves to be able to figure out if we need to run and individual test or not. Whilst I haven't committed it in this PR, I can confirm that using the application context and local/browserstack variants like this, we can get multiple compatibility tests running.