### PR TITLE
Upload the test status at the end of browserstack test scenarios.

### DIFF
--- a/src/test/java/uk/gov/dhsc/htbhf/BrowserStackConfiguration.java
+++ b/src/test/java/uk/gov/dhsc/htbhf/BrowserStackConfiguration.java
@@ -6,6 +6,7 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Profile;
 import org.springframework.context.annotation.PropertySource;
+import uk.gov.dhsc.htbhf.browserstack.BrowserStackResultUploader;
 import uk.gov.dhsc.htbhf.utils.NoopWireMockManager;
 import uk.gov.dhsc.htbhf.utils.WireMockManager;
 
@@ -32,5 +33,10 @@ public class BrowserStackConfiguration {
     @Bean
     public WireMockManager noopWireMockManager() {
         return new NoopWireMockManager();
+    }
+
+    @Bean
+    public BrowserStackResultUploader browserStackResultUploader() {
+        return new BrowserStackResultUploader(browserStackUser, browserStackKey);
     }
 }

--- a/src/test/java/uk/gov/dhsc/htbhf/LocalConfiguration.java
+++ b/src/test/java/uk/gov/dhsc/htbhf/LocalConfiguration.java
@@ -47,4 +47,9 @@ public class LocalConfiguration {
     public WireMockManager wireMockManagerImpl(WireMockServer wireMockServer) {
         return new WireMockManagerImpl(wireMockServer);
     }
+
+    @Bean
+    public TestResultHandler testResultHandler() {
+        return new NoopTestResultHandler();
+    }
 }

--- a/src/test/java/uk/gov/dhsc/htbhf/NoopTestResultHandler.java
+++ b/src/test/java/uk/gov/dhsc/htbhf/NoopTestResultHandler.java
@@ -1,0 +1,7 @@
+package uk.gov.dhsc.htbhf;
+
+/**
+ * No-op implementation for local testing.
+ */
+public class NoopTestResultHandler implements TestResultHandler {
+}

--- a/src/test/java/uk/gov/dhsc/htbhf/TestResult.java
+++ b/src/test/java/uk/gov/dhsc/htbhf/TestResult.java
@@ -1,0 +1,15 @@
+package uk.gov.dhsc.htbhf;
+
+import io.cucumber.core.api.Scenario;
+import lombok.Data;
+
+@Data
+public class TestResult {
+    private String name;
+    private String status;
+
+    public TestResult(Scenario scenario) {
+        this.name = scenario.getName();
+        this.status = scenario.isFailed() ? "failed" : "passed";
+    }
+}

--- a/src/test/java/uk/gov/dhsc/htbhf/TestResultHandler.java
+++ b/src/test/java/uk/gov/dhsc/htbhf/TestResultHandler.java
@@ -1,0 +1,8 @@
+package uk.gov.dhsc.htbhf;
+
+public interface TestResultHandler {
+
+    default void handleResults(TestResult testResult, String sessionId) {
+
+    }
+}

--- a/src/test/java/uk/gov/dhsc/htbhf/browserstack/BrowserStackResultUploader.java
+++ b/src/test/java/uk/gov/dhsc/htbhf/browserstack/BrowserStackResultUploader.java
@@ -1,0 +1,56 @@
+package uk.gov.dhsc.htbhf.browserstack;
+
+import lombok.extern.slf4j.Slf4j;
+import org.apache.http.NameValuePair;
+import org.apache.http.client.entity.UrlEncodedFormEntity;
+import org.apache.http.client.methods.HttpPut;
+import org.apache.http.impl.client.HttpClientBuilder;
+import org.apache.http.message.BasicNameValuePair;
+import uk.gov.dhsc.htbhf.TestResult;
+import uk.gov.dhsc.htbhf.TestResultHandler;
+
+import java.io.UnsupportedEncodingException;
+import java.net.URI;
+import java.util.ArrayList;
+
+/**
+ * Uploads the result to BrowserStack after the test is completed otherwise tests that fail are marked as passing.
+ */
+@Slf4j
+public class BrowserStackResultUploader implements TestResultHandler {
+
+    private final String browserStackUser;
+    private final String browserStackKey;
+
+    public BrowserStackResultUploader(String browserStackUser, String browserStackKey) {
+        this.browserStackUser = browserStackUser;
+        this.browserStackKey = browserStackKey;
+    }
+
+    @Override
+    public void handleResults(TestResult testResult, String sessionId) {
+        try {
+            String url = buildUrlForSession(sessionId);
+            URI uri = new URI(url);
+            HttpPut putRequest = buildPutRequest(testResult, uri);
+
+            HttpClientBuilder.create().build().execute(putRequest);
+        } catch (Exception e) {
+            log.error("Unexpected Exception caught trying to post results to BrowserStack", e);
+        }
+    }
+
+    private HttpPut buildPutRequest(TestResult testResult, URI uri) throws UnsupportedEncodingException {
+        HttpPut putRequest = new HttpPut(uri);
+
+        ArrayList<NameValuePair> nameValuePairs = new ArrayList<>();
+        nameValuePairs.add((new BasicNameValuePair("status", testResult.getStatus())));
+        nameValuePairs.add((new BasicNameValuePair("name", testResult.getName())));
+        putRequest.setEntity(new UrlEncodedFormEntity(nameValuePairs));
+        return putRequest;
+    }
+
+    private String buildUrlForSession(String sessionId) {
+        return String.format("https://%s:%s@api.browserstack.com/automate/sessions/%s.json", browserStackUser, browserStackKey, sessionId);
+    }
+}

--- a/src/test/java/uk/gov/dhsc/htbhf/steps/BaseSteps.java
+++ b/src/test/java/uk/gov/dhsc/htbhf/steps/BaseSteps.java
@@ -4,6 +4,7 @@ import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.support.ui.WebDriverWait;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
+import uk.gov.dhsc.htbhf.TestResultHandler;
 import uk.gov.dhsc.htbhf.WebDriverWrapper;
 import uk.gov.dhsc.htbhf.utils.WireMockManager;
 
@@ -19,6 +20,9 @@ public abstract class BaseSteps {
 
     @Autowired
     protected WireMockManager wireMockManager;
+
+    @Autowired
+    protected TestResultHandler testResultHandler;
 
     @Value("${base.url}")
     protected String baseUrl;


### PR DESCRIPTION
Added as an extra @After hook at the end of BrowserStack tests to make sure that the status is set to Failed if there is an assertion failure.