### PR TITLE
Create Compatability test report HTML file on completion

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -58,6 +58,10 @@ dependencies {
     testImplementation "com.github.tomakehurst:wiremock-jre8:2.24.1"
     testImplementation "org.apache.commons:commons-lang3:3.9"
     testImplementation "ch.qos.logback:logback-classic:1.2.3"
+    testImplementation "org.apache.velocity:velocity:1.7"
+    testImplementation "org.apache.velocity:velocity-tools:2.0"
+    testImplementation "org.apache.velocity:velocity-tools:2.0"
+    testImplementation "org.mockito:mockito-junit-jupiter:2.23.4"
 }
 
 test {

--- a/src/test/java/uk/gov/dhsc/htbhf/BrowserStackLauncher.java
+++ b/src/test/java/uk/gov/dhsc/htbhf/BrowserStackLauncher.java
@@ -15,9 +15,12 @@ import org.springframework.retry.policy.SimpleRetryPolicy;
 import org.springframework.retry.support.RetryTemplate;
 import org.springframework.util.CollectionUtils;
 import uk.gov.dhsc.htbhf.browserstack.RetryTriggerException;
+import uk.gov.dhsc.htbhf.browserstack.TestOutputHtmlGenerator;
 import uk.gov.dhsc.htbhf.browserstack.TestResultSummary;
 import uk.gov.dhsc.htbhf.steps.Hooks;
 
+import java.io.File;
+import java.io.IOException;
 import java.util.List;
 import java.util.concurrent.*;
 
@@ -32,6 +35,9 @@ public class BrowserStackLauncher {
 
     private static final int MAX_THREADS = 5;
     private static final int MAX_RETRY_ATTEMPTS = 3;
+    private static final int TOTAL_TIMEOUT_MINS = 10;
+    private static final String COMPATIBILITY_REPORT_DIR = "build/reports/compatibility-report";
+    private static final String COMPATIBILITY_REPORT_FILE = COMPATIBILITY_REPORT_DIR + "/compatibility-report.html";
     private static ThreadLocal<String> testNameLocal = new ThreadLocal<>();
     private static ExecutorService executorService;
     private static final List<TestResultSummary> results = new CopyOnWriteArrayList<>();
@@ -72,19 +78,27 @@ public class BrowserStackLauncher {
                     .toArray(CompletableFuture[]::new);
             CompletableFuture<Void> combinedFuture = CompletableFuture.allOf(completableFuturesArray);
 
-            combinedFuture.get();
-        } catch (InterruptedException e) {
-            log.error("InterruptedException caught trying to run task", e);
-        } catch (ExecutionException e) {
-            log.error("ExecutionException caught trying to run task", e);
+            combinedFuture.get(TOTAL_TIMEOUT_MINS, TimeUnit.MINUTES);
+
+            outputReport();
+        } catch (InterruptedException ie) {
+            log.error("InterruptedException caught trying to run task", ie);
+        } catch (ExecutionException ee) {
+            log.error("ExecutionException caught trying to run task", ee);
+        } catch (TimeoutException te) {
+            log.error("TimeoutException caught trying to run task", te);
+        } catch (IOException ioe) {
+            log.error("IOException caught trying to write out the compatibility test report", ioe);
         } finally {
             executorService.shutdown();
         }
-        outputResults();
     }
 
-    private static void outputResults() {
-        results.forEach(resultSummary -> log.info(">>>>>>>>>>>>ResultSummary: {}", resultSummary));
+    private static void outputReport() throws IOException {
+        File reportDir = new File(COMPATIBILITY_REPORT_DIR);
+        reportDir.mkdirs();
+        TestOutputHtmlGenerator.generateHtmlReport(results, COMPATIBILITY_REPORT_FILE);
+        log.info("Compatibility test report output to: {}", COMPATIBILITY_REPORT_FILE);
     }
 
     private static TestExecutionSummary runTest(String testName) {
@@ -126,7 +140,6 @@ public class BrowserStackLauncher {
         return summary;
     }
 
-    //TODO MRS 2019-08-29: Add a link to the build via sessionId if fails.
     private static void checkForFailures(String testName, RetryContext context, TestExecutionSummary summary) {
         int attemptNumber = context.getRetryCount() + 1;
         storeTestRunSummary(testName, summary, attemptNumber);
@@ -144,9 +157,9 @@ public class BrowserStackLauncher {
         root.setLevel(Level.INFO);
     }
 
-    private static void storeTestRunSummary(String testName, TestExecutionSummary summary, int attempts) {
+    private static void storeTestRunSummary(String testName, TestExecutionSummary summary, int attempt) {
         String sessionId = Hooks.getSessionIdThreadLocal().get();
-        TestResultSummary result = new TestResultSummary(summary, testName, attempts, sessionId);
+        TestResultSummary result = new TestResultSummary(summary, testName, attempt, sessionId);
         results.add(result);
     }
 }

--- a/src/test/java/uk/gov/dhsc/htbhf/browserstack/BrowserStackResultUploader.java
+++ b/src/test/java/uk/gov/dhsc/htbhf/browserstack/BrowserStackResultUploader.java
@@ -29,7 +29,7 @@ public class BrowserStackResultUploader implements TestResultHandler {
 
     @Override
     public void handleResults(TestResult testResult, String sessionId) {
-        log.info("Uploading results for test with sessionId: {}", sessionId);
+        log.info("Uploading results [{}] for test with sessionId: {}", testResult, sessionId);
         try {
             String url = buildUrlForSession(sessionId);
             URI uri = new URI(url);

--- a/src/test/java/uk/gov/dhsc/htbhf/browserstack/TestOutputHtmlGenerator.java
+++ b/src/test/java/uk/gov/dhsc/htbhf/browserstack/TestOutputHtmlGenerator.java
@@ -1,0 +1,42 @@
+package uk.gov.dhsc.htbhf.browserstack;
+
+import org.apache.velocity.Template;
+import org.apache.velocity.VelocityContext;
+import org.apache.velocity.app.VelocityEngine;
+import org.apache.velocity.runtime.RuntimeConstants;
+import org.apache.velocity.runtime.resource.loader.ClasspathResourceLoader;
+
+import java.io.IOException;
+import java.io.StringWriter;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+
+/**
+ * Generates an HTML file from the provided test results
+ */
+public class TestOutputHtmlGenerator {
+
+    private static final String VELOCITY_TEMPLATE_LOCATION = "velocity/index.vm";
+
+    public static void generateHtmlReport(List<TestResultSummary> resultSummaries, String reportLocation) throws IOException {
+        VelocityEngine velocityEngine = setupVelocityEngine();
+
+        Template velocityEngineTemplate = velocityEngine.getTemplate(VELOCITY_TEMPLATE_LOCATION);
+
+        VelocityContext velocityContext = new VelocityContext();
+        velocityContext.put("resultSummaries", resultSummaries);
+
+        StringWriter writer = new StringWriter();
+        velocityEngineTemplate.merge(velocityContext, writer);
+        Files.writeString(Path.of(reportLocation), writer.toString());
+    }
+
+    private static VelocityEngine setupVelocityEngine() {
+        VelocityEngine velocityEngine = new VelocityEngine();
+        velocityEngine.setProperty(RuntimeConstants.RESOURCE_LOADER, "classpath");
+        velocityEngine.setProperty("classpath.resource.loader.class", ClasspathResourceLoader.class.getName());
+        velocityEngine.init();
+        return velocityEngine;
+    }
+}

--- a/src/test/java/uk/gov/dhsc/htbhf/browserstack/TestOutputHtmlGeneratorTest.java
+++ b/src/test/java/uk/gov/dhsc/htbhf/browserstack/TestOutputHtmlGeneratorTest.java
@@ -1,0 +1,64 @@
+package uk.gov.dhsc.htbhf.browserstack;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.platform.launcher.listeners.TestExecutionSummary;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.mock;
+
+@ExtendWith(MockitoExtension.class)
+class TestOutputHtmlGeneratorTest {
+
+    private static final String REPORT_LOCATION = "test-report.html";
+
+    @Test
+    void shouldOutputReportFile() throws IOException {
+        try {
+            //Given
+            List<TestResultSummary> resultSummaries = new ArrayList<>();
+            TestExecutionSummary testExecutionSummary = setupMockTestExecutionSummary();
+            resultSummaries.add(new TestResultSummary(testExecutionSummary, "Test1", 3, "kjhndfsd98rkbnjsdfh"));
+
+            //When
+            TestOutputHtmlGenerator.generateHtmlReport(resultSummaries, REPORT_LOCATION);
+
+            //Then
+            String reportContents = Files.readString(Path.of(REPORT_LOCATION));
+            assertThat(reportContents).isNotBlank();
+            assertThat(reportContents).startsWith("<!DOCTYPE html>");
+            assertThat(reportContents).contains(
+                    "<h1>Compatibility Test Summary</h1>",
+                    "<td>Test1</td>",
+                    "<td>true</td>",
+                    "<td>true</td>",
+                    "<td>1970-01-01 01:00:00</td>",
+                    "<td>1970-01-01 01:00:10</td>",
+                    "<td>00:09</td>",
+                    "<td>3</td>",
+                    "<td>kjhndfsd98rkbnjsdfh</td>"
+            );
+        } finally {
+            Files.delete(Path.of(REPORT_LOCATION));
+        }
+    }
+
+    private TestExecutionSummary setupMockTestExecutionSummary() {
+        TestExecutionSummary testExecutionSummary = mock(TestExecutionSummary.class);
+        given(testExecutionSummary.getFailures()).willReturn(Collections.emptyList());
+        given(testExecutionSummary.getTimeStarted()).willReturn(100L);
+        given(testExecutionSummary.getTimeFinished()).willReturn(10000L);
+        given(testExecutionSummary.getTimeFinished()).willReturn(10000L);
+        return testExecutionSummary;
+    }
+
+}

--- a/src/test/java/uk/gov/dhsc/htbhf/browserstack/TestResultSummary.java
+++ b/src/test/java/uk/gov/dhsc/htbhf/browserstack/TestResultSummary.java
@@ -7,13 +7,22 @@ import org.junit.platform.launcher.listeners.TestExecutionSummary;
 import java.time.Instant;
 import java.time.LocalDateTime;
 import java.time.ZoneId;
+import java.time.format.DateTimeFormatter;
 
+/**
+ * The summary of an individual compatibility test run
+ */
 @Data
 public class TestResultSummary {
+
+    private static final DateTimeFormatter DATE_TIME_FORMATTER = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss");
+
     private String testName;
     private boolean passed;
     private LocalDateTime startedTime;
+    private String formattedStartTime;
     private LocalDateTime finishedTime;
+    private String formattedEndTime;
     private String duration;
     private int attempts;
     private Throwable failure;
@@ -22,12 +31,19 @@ public class TestResultSummary {
     public TestResultSummary(TestExecutionSummary testExecutionSummary, String testName, int attempts, String sessionId) {
         this.testName = testName;
         this.passed = testExecutionSummary.getFailures().isEmpty();
-        this.startedTime = LocalDateTime.ofInstant(Instant.ofEpochMilli(testExecutionSummary.getTimeStarted()), ZoneId.systemDefault());
-        this.finishedTime = LocalDateTime.ofInstant(Instant.ofEpochMilli(testExecutionSummary.getTimeFinished()), ZoneId.systemDefault());
+        this.startedTime = toLocalDateTime(testExecutionSummary.getTimeStarted());
+        this.formattedStartTime = startedTime.format(DATE_TIME_FORMATTER);
+        this.finishedTime = toLocalDateTime(testExecutionSummary.getTimeFinished());
+        this.formattedEndTime = finishedTime.format(DATE_TIME_FORMATTER);
         long durationLong = testExecutionSummary.getTimeFinished() - testExecutionSummary.getTimeStarted();
         this.duration = DurationFormatUtils.formatDuration(durationLong, "mm:ss", true);
         this.failure = passed ? null : testExecutionSummary.getFailures().get(0).getException();
         this.attempts = attempts;
         this.sessionId = sessionId;
     }
+
+    private LocalDateTime toLocalDateTime(long timeMillis) {
+        return LocalDateTime.ofInstant(Instant.ofEpochMilli(timeMillis), ZoneId.systemDefault());
+    }
+
 }

--- a/src/test/java/uk/gov/dhsc/htbhf/browserstack/TestResultSummary.java
+++ b/src/test/java/uk/gov/dhsc/htbhf/browserstack/TestResultSummary.java
@@ -1,0 +1,33 @@
+package uk.gov.dhsc.htbhf.browserstack;
+
+import lombok.Data;
+import org.apache.commons.lang3.time.DurationFormatUtils;
+import org.junit.platform.launcher.listeners.TestExecutionSummary;
+
+import java.time.Instant;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+
+@Data
+public class TestResultSummary {
+    private String testName;
+    private boolean passed;
+    private LocalDateTime startedTime;
+    private LocalDateTime finishedTime;
+    private String duration;
+    private int attempts;
+    private Throwable failure;
+    private String sessionId;
+
+    public TestResultSummary(TestExecutionSummary testExecutionSummary, String testName, int attempts, String sessionId) {
+        this.testName = testName;
+        this.passed = testExecutionSummary.getFailures().isEmpty();
+        this.startedTime = LocalDateTime.ofInstant(Instant.ofEpochMilli(testExecutionSummary.getTimeStarted()), ZoneId.systemDefault());
+        this.finishedTime = LocalDateTime.ofInstant(Instant.ofEpochMilli(testExecutionSummary.getTimeFinished()), ZoneId.systemDefault());
+        long durationLong = testExecutionSummary.getTimeFinished() - testExecutionSummary.getTimeStarted();
+        this.duration = DurationFormatUtils.formatDuration(durationLong, "mm:ss", true);
+        this.failure = passed ? null : testExecutionSummary.getFailures().get(0).getException();
+        this.attempts = attempts;
+        this.sessionId = sessionId;
+    }
+}

--- a/src/test/java/uk/gov/dhsc/htbhf/steps/Hooks.java
+++ b/src/test/java/uk/gov/dhsc/htbhf/steps/Hooks.java
@@ -8,6 +8,12 @@ import uk.gov.dhsc.htbhf.TestResult;
 
 public class Hooks extends BaseSteps {
 
+    private static ThreadLocal<String> sessionIdThreadLocal = new ThreadLocal<>();
+
+    public static ThreadLocal<String> getSessionIdThreadLocal() {
+        return sessionIdThreadLocal;
+    }
+
     /**
      * As we have to always quit the driver for BrowserStack tests, we need to initialise a new one for each new test.
      */
@@ -26,6 +32,7 @@ public class Hooks extends BaseSteps {
         if (isBrowserStackProfile()) {
             try {
                 String sessionId = getSessionId();
+                sessionIdThreadLocal.set(sessionId);
                 TestResult sessionDetails = new TestResult(scenario);
                 testResultHandler.handleResults(sessionDetails, sessionId);
             } finally {

--- a/src/test/resources/velocity/index.vm
+++ b/src/test/resources/velocity/index.vm
@@ -1,0 +1,35 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <meta http-equiv="Content-Type" content="text/html; charset=utf-8"/>
+    <title>Test results</title>
+</head>
+<body>
+<h1>Compatibility Test Summary</h1>
+
+<table border="1">
+    <tr>
+        <th>Test</th>
+        <th>Passed</th>
+        <th>Start Time</th>
+        <th>Finished Time</th>
+        <th>Duration</th>
+        <th>Attempt</th>
+        <th>Session Id</th>
+        <th>Failure</th>
+    </tr>
+    #foreach( $resultSummary in $resultSummaries )
+        <tr>
+            <td>$resultSummary.getTestName()</td>
+            <td>$resultSummary.isPassed()</td>
+            <td>$resultSummary.getFormattedStartTime()</td>
+            <td>$resultSummary.getFormattedEndTime()</td>
+            <td>$resultSummary.getDuration()</td>
+            <td>$resultSummary.getAttempts()</td>
+            <td>$resultSummary.getSessionId()</td>
+            <td>#if( $resultSummary.getFailure() ) $resultSummary.getFailure() #end</td>
+        </tr>
+    #end
+</table>
+
+</body>


### PR DESCRIPTION
 - Add generation of a custom (basic) HTML report at the end of a compatibility test report.
 - Uses Velocity to pass values into a template HTML file.
 - Will output results from all test runs including all failed runs, including the Exception reported.
 - Added a total timeout for waiting for all tests to complete (I had a test that never ended locally so thought this was important). Timeout of 10 minutes might be a bit skinny though.
 - Re-enabled the mac-mojave-safari test as it was originally disabled due to the basic auth problem with Safari. This is no longer a problem as we use a temporary route so this can be run again.

From here we can improve/massage the contents of the report as we wish, but all the detail should be there.