### PR TITLE
Create Compatability test report HTML file on completion 

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -25,7 +25,7 @@ jobs:
             - "81:ca:95:90:1b:25:e9:cb:e7:0c:89:41:b8:cf:7f:a0"
       - run:
           name: prepare for tests and build
-          command: ./ci_scripts/prepare_for_tests.sh && ./gradlew clean build -s
+          command: ./ci_scripts/prepare_for_tests.sh && ./gradlew clean build --info -s
       - run:
           name: cat the RunAcceptanceTests logs for debugging on failure
           command: cat /home/circleci/project/build/reports/tests/test/classes/uk.gov.dhsc.htbhf.RunAcceptanceTests.html

--- a/build.gradle
+++ b/build.gradle
@@ -48,6 +48,10 @@ dependencies {
     testImplementation "org.junit.jupiter:junit-jupiter-params:${junitVersion}"
     testImplementation "org.junit.vintage:junit-vintage-engine:${junitVersion}"
     testImplementation "org.junit.platform:junit-platform-console:1.5.1"
+    testImplementation "org.apache.velocity:velocity:1.7"
+    testImplementation "org.apache.velocity:velocity-tools:2.0"
+    testImplementation "org.apache.velocity:velocity-tools:2.0"
+    testImplementation "org.mockito:mockito-junit-jupiter:2.23.4"
 
     testImplementation "org.seleniumhq.selenium:selenium-java:${seleniumVersion}"
     testImplementation "org.springframework:spring-test:${springVersion}"

--- a/src/test/java/uk/gov/dhsc/htbhf/browserstack/BrowserStackResultUploader.java
+++ b/src/test/java/uk/gov/dhsc/htbhf/browserstack/BrowserStackResultUploader.java
@@ -29,7 +29,7 @@ public class BrowserStackResultUploader implements TestResultHandler {
 
     @Override
     public void handleResults(TestResult testResult, String sessionId) {
-        log.info("Uploading results for test with sessionId: {}", sessionId);
+        log.info("Uploading results [{}] for test with sessionId: {}", testResult, sessionId);
         try {
             String url = buildUrlForSession(sessionId);
             URI uri = new URI(url);

--- a/src/test/java/uk/gov/dhsc/htbhf/browserstack/TestOutputHtmlGenerator.java
+++ b/src/test/java/uk/gov/dhsc/htbhf/browserstack/TestOutputHtmlGenerator.java
@@ -1,0 +1,42 @@
+package uk.gov.dhsc.htbhf.browserstack;
+
+import org.apache.velocity.Template;
+import org.apache.velocity.VelocityContext;
+import org.apache.velocity.app.VelocityEngine;
+import org.apache.velocity.runtime.RuntimeConstants;
+import org.apache.velocity.runtime.resource.loader.ClasspathResourceLoader;
+
+import java.io.IOException;
+import java.io.StringWriter;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+
+/**
+ * Generates an HTML file from the provided test results
+ */
+public class TestOutputHtmlGenerator {
+
+    private static final String VELOCITY_TEMPLATE_LOCATION = "velocity/results-summary.vm";
+
+    public static void generateHtmlReport(List<TestResultSummary> resultSummaries, String reportLocation) throws IOException {
+        VelocityEngine velocityEngine = setupVelocityEngine();
+
+        Template velocityEngineTemplate = velocityEngine.getTemplate(VELOCITY_TEMPLATE_LOCATION);
+
+        VelocityContext velocityContext = new VelocityContext();
+        velocityContext.put("resultSummaries", resultSummaries);
+
+        StringWriter writer = new StringWriter();
+        velocityEngineTemplate.merge(velocityContext, writer);
+        Files.writeString(Path.of(reportLocation), writer.toString());
+    }
+
+    private static VelocityEngine setupVelocityEngine() {
+        VelocityEngine velocityEngine = new VelocityEngine();
+        velocityEngine.setProperty(RuntimeConstants.RESOURCE_LOADER, "classpath");
+        velocityEngine.setProperty("classpath.resource.loader.class", ClasspathResourceLoader.class.getName());
+        velocityEngine.init();
+        return velocityEngine;
+    }
+}

--- a/src/test/java/uk/gov/dhsc/htbhf/browserstack/TestOutputHtmlGeneratorTest.java
+++ b/src/test/java/uk/gov/dhsc/htbhf/browserstack/TestOutputHtmlGeneratorTest.java
@@ -1,0 +1,68 @@
+package uk.gov.dhsc.htbhf.browserstack;
+
+import lombok.extern.slf4j.Slf4j;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.platform.launcher.listeners.TestExecutionSummary;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Collections;
+import java.util.List;
+
+import static java.util.Collections.singletonList;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.mock;
+
+@Slf4j
+@ExtendWith(MockitoExtension.class)
+class TestOutputHtmlGeneratorTest {
+
+    private static final String REPORT_LOCATION = "test-report.html";
+    private static final String SESSION_ID = "kjhndfsd98rkbnjsdfh";
+    private static final String TEST_NAME = "Test1";
+    private static final int ATTEMPTS = 3;
+
+    @Test
+    void shouldOutputReportFile() throws IOException {
+        try {
+            //Given
+            TestExecutionSummary testExecutionSummary = setupMockTestExecutionSummary();
+            TestResultSummary testResultSummary = new TestResultSummary(testExecutionSummary, TEST_NAME, ATTEMPTS, SESSION_ID);
+            List<TestResultSummary> resultSummaries = singletonList(testResultSummary);
+
+            //When
+            TestOutputHtmlGenerator.generateHtmlReport(resultSummaries, REPORT_LOCATION);
+
+            //Then
+            String reportContents = Files.readString(Path.of(REPORT_LOCATION));
+            assertThat(reportContents).isNotBlank();
+            assertThat(reportContents).startsWith("<!DOCTYPE html>");
+            assertThat(reportContents).contains(
+                    "<h1>Compatibility Test Summary</h1>",
+                    "<td>Test1</td>",
+                    "<td>true</td>",
+                    "<td>00:09</td>",
+                    "<td>3</td>",
+                    "<td>kjhndfsd98rkbnjsdfh</td>",
+                    "<td>" + testResultSummary.getFormattedStartTime() + "</td>",
+                    "<td>" + testResultSummary.getFormattedEndTime() + "</td>"
+            );
+        } finally {
+            Files.delete(Path.of(REPORT_LOCATION));
+        }
+    }
+
+    private TestExecutionSummary setupMockTestExecutionSummary() {
+        TestExecutionSummary testExecutionSummary = mock(TestExecutionSummary.class);
+        given(testExecutionSummary.getFailures()).willReturn(Collections.emptyList());
+        given(testExecutionSummary.getTimeStarted()).willReturn(100L);
+        given(testExecutionSummary.getTimeFinished()).willReturn(10000L);
+        given(testExecutionSummary.getTimeFinished()).willReturn(10000L);
+        return testExecutionSummary;
+    }
+
+}

--- a/src/test/java/uk/gov/dhsc/htbhf/browserstack/TestResultSummary.java
+++ b/src/test/java/uk/gov/dhsc/htbhf/browserstack/TestResultSummary.java
@@ -15,7 +15,7 @@ import java.time.format.DateTimeFormatter;
 @Data
 public class TestResultSummary {
 
-    public static final DateTimeFormatter DATE_TIME_FORMATTER = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss");
+    private static final DateTimeFormatter DATE_TIME_FORMATTER = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss");
 
     private String testName;
     private boolean passed;

--- a/src/test/java/uk/gov/dhsc/htbhf/browserstack/TestResultSummary.java
+++ b/src/test/java/uk/gov/dhsc/htbhf/browserstack/TestResultSummary.java
@@ -1,0 +1,49 @@
+package uk.gov.dhsc.htbhf.browserstack;
+
+import lombok.Data;
+import org.apache.commons.lang3.time.DurationFormatUtils;
+import org.junit.platform.launcher.listeners.TestExecutionSummary;
+
+import java.time.Instant;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.time.format.DateTimeFormatter;
+
+/**
+ * The summary of an individual compatibility test run
+ */
+@Data
+public class TestResultSummary {
+
+    public static final DateTimeFormatter DATE_TIME_FORMATTER = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss");
+
+    private String testName;
+    private boolean passed;
+    private LocalDateTime startedTime;
+    private String formattedStartTime;
+    private LocalDateTime finishedTime;
+    private String formattedEndTime;
+    private String duration;
+    private int attempts;
+    private Throwable failure;
+    private String sessionId;
+
+    public TestResultSummary(TestExecutionSummary testExecutionSummary, String testName, int attempts, String sessionId) {
+        this.testName = testName;
+        this.passed = testExecutionSummary.getFailures().isEmpty();
+        this.startedTime = toLocalDateTime(testExecutionSummary.getTimeStarted());
+        this.formattedStartTime = startedTime.format(DATE_TIME_FORMATTER);
+        this.finishedTime = toLocalDateTime(testExecutionSummary.getTimeFinished());
+        this.formattedEndTime = finishedTime.format(DATE_TIME_FORMATTER);
+        long durationLong = testExecutionSummary.getTimeFinished() - testExecutionSummary.getTimeStarted();
+        this.duration = DurationFormatUtils.formatDuration(durationLong, "mm:ss", true);
+        this.failure = passed ? null : testExecutionSummary.getFailures().get(0).getException();
+        this.attempts = attempts;
+        this.sessionId = sessionId;
+    }
+
+    private LocalDateTime toLocalDateTime(long timeMillis) {
+        return LocalDateTime.ofInstant(Instant.ofEpochMilli(timeMillis), ZoneId.systemDefault());
+    }
+
+}

--- a/src/test/java/uk/gov/dhsc/htbhf/steps/Hooks.java
+++ b/src/test/java/uk/gov/dhsc/htbhf/steps/Hooks.java
@@ -8,6 +8,12 @@ import uk.gov.dhsc.htbhf.TestResult;
 
 public class Hooks extends BaseSteps {
 
+    private static ThreadLocal<String> sessionIdThreadLocal = new ThreadLocal<>();
+
+    public static ThreadLocal<String> getSessionIdThreadLocal() {
+        return sessionIdThreadLocal;
+    }
+
     /**
      * As we have to always quit the driver for BrowserStack tests, we need to initialise a new one for each new test.
      */
@@ -26,6 +32,7 @@ public class Hooks extends BaseSteps {
         if (isBrowserStackProfile()) {
             try {
                 String sessionId = getSessionId();
+                sessionIdThreadLocal.set(sessionId);
                 TestResult sessionDetails = new TestResult(scenario);
                 testResultHandler.handleResults(sessionDetails, sessionId);
             } finally {

--- a/src/test/resources/application-browserstack.properties
+++ b/src/test/resources/application-browserstack.properties
@@ -1,2 +1,2 @@
-base.url=https://apply-for-healthy-start-staging.london.cloudapps.digital
-session.details.url=https://apply-for-healthy-start-staging.london.cloudapps.digital/session-details/confirmation-code
+base.url=${APP_BASE:https://apply-for-healthy-start-staging.london.cloudapps.digital}
+session.details.url=${SESSION_DETAILS_URL:https://apply-for-healthy-start-staging.london.cloudapps.digital/session-details/confirmation-code}

--- a/src/test/resources/velocity/results-summary.vm
+++ b/src/test/resources/velocity/results-summary.vm
@@ -1,0 +1,35 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <meta http-equiv="Content-Type" content="text/html; charset=utf-8"/>
+    <title>Test results</title>
+</head>
+<body>
+<h1>Compatibility Test Summary</h1>
+
+<table border="1">
+    <tr>
+        <th>Test</th>
+        <th>Passed</th>
+        <th>Start Time</th>
+        <th>Finished Time</th>
+        <th>Duration</th>
+        <th>Attempt</th>
+        <th>Session Id</th>
+        <th>Failure</th>
+    </tr>
+    #foreach( $resultSummary in $resultSummaries )
+        <tr>
+            <td>$resultSummary.getTestName()</td>
+            <td>$resultSummary.isPassed()</td>
+            <td>$resultSummary.getFormattedStartTime()</td>
+            <td>$resultSummary.getFormattedEndTime()</td>
+            <td>$resultSummary.getDuration()</td>
+            <td>$resultSummary.getAttempts()</td>
+            <td>$resultSummary.getSessionId()</td>
+            <td>#if( $resultSummary.getFailure() ) $resultSummary.getFailure() #end</td>
+        </tr>
+    #end
+</table>
+
+</body>


### PR DESCRIPTION
 - Add generation of a custom (basic) HTML report at the end of a compatibility test report.
 - Uses Velocity to pass values into a template HTML file.
 - Will output results from all test runs including all failed runs, including the Exception reported.
 - Added a total timeout for waiting for all tests to complete (I had a test that never ended locally so thought this was important). Timeout of 15 minutes might be a bit skinny though.
 - Re-enabled the mac-mojave-safari test as it was originally disabled due to the basic auth problem with Safari. This is no longer a problem as we use a temporary route so this can be run again.
 - URLs to use for Browserstack testing can now be configured by environment variables.

From here we can improve/massage the contents of the report as we wish, but all the detail should be there.