### PR TITLE
Create central place to register page objects so that we can easily retrieve them by page name.

### DIFF
--- a/src/test/java/uk/gov/dhsc/htbhf/WebDriverWrapper.java
+++ b/src/test/java/uk/gov/dhsc/htbhf/WebDriverWrapper.java
@@ -2,6 +2,7 @@ package uk.gov.dhsc.htbhf;
 
 import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.support.ui.WebDriverWait;
+import uk.gov.dhsc.htbhf.page.Pages;
 
 /**
  * Wraps the lifecycle of a WebDriver and WebDriverWait.
@@ -11,6 +12,8 @@ public interface WebDriverWrapper {
     WebDriver getWebDriver();
 
     WebDriverWait getWebDriverWait();
+
+    Pages getPages();
 
     void initDriver();
 

--- a/src/test/java/uk/gov/dhsc/htbhf/browserstack/BrowserStackConfiguration.java
+++ b/src/test/java/uk/gov/dhsc/htbhf/browserstack/BrowserStackConfiguration.java
@@ -25,9 +25,12 @@ public class BrowserStackConfiguration {
     @Value("${wait.timeout.seconds}")
     private int waitTimeoutInSeconds;
 
+    @Value("${base.url}")
+    private String baseUrl;
+
     @Bean
     public WebDriverWrapper browserStackDriverBuilder() {
-        return new BrowserStackDriverWrapper(browserStackUser, browserStackKey, waitTimeoutInSeconds);
+        return new BrowserStackDriverWrapper(browserStackUser, browserStackKey, waitTimeoutInSeconds, baseUrl);
     }
 
     @Bean

--- a/src/test/java/uk/gov/dhsc/htbhf/browserstack/BrowserStackDriverWrapper.java
+++ b/src/test/java/uk/gov/dhsc/htbhf/browserstack/BrowserStackDriverWrapper.java
@@ -7,6 +7,7 @@ import org.openqa.selenium.remote.DesiredCapabilities;
 import org.openqa.selenium.remote.RemoteWebDriver;
 import org.openqa.selenium.support.ui.WebDriverWait;
 import uk.gov.dhsc.htbhf.WebDriverWrapper;
+import uk.gov.dhsc.htbhf.page.Pages;
 
 import java.net.MalformedURLException;
 import java.net.URL;
@@ -31,17 +32,22 @@ public class BrowserStackDriverWrapper implements WebDriverWrapper {
 
     private final URL browserStackUrl;
 
+    private final String baseUrl;
+
     private ThreadLocal<WebDriver> webDriver = new ThreadLocal<>();
 
     private ThreadLocal<WebDriverWait> webDriverWait = new ThreadLocal<>();
 
-    public BrowserStackDriverWrapper(String browserStackUser, String browserStackKey, int waitTimeoutInSeconds) {
+    private Pages pages;
+
+    public BrowserStackDriverWrapper(String browserStackUser, String browserStackKey, int waitTimeoutInSeconds, String baseUrl) {
         Validate.notBlank(browserStackUser, "BrowserStack user must be provided, set the BROWSER_STACK_USER environment variable");
         Validate.notBlank(browserStackKey, "BrowserStack key must be provided, set the BROWSER_STACK_KEY environment variable");
         this.browserStackUser = browserStackUser;
         this.browserStackKey = browserStackKey;
         this.waitTimeoutInSeconds = waitTimeoutInSeconds;
         this.browserStackUrl = buildBrowserStackUrl();
+        this.baseUrl = baseUrl;
     }
 
     @Override
@@ -55,12 +61,18 @@ public class BrowserStackDriverWrapper implements WebDriverWrapper {
     }
 
     @Override
+    public Pages getPages() {
+        return pages;
+    }
+
+    @Override
     public void initDriver() {
         Map<String, String> browserStackCapabilities = getBrowserStackCapabilities();
         log.info("Using capabilities: {}", browserStackCapabilities);
         DesiredCapabilities desiredCapabilities = buildDesiredCapabilities(browserStackCapabilities, browserStackUser, browserStackKey);
         this.webDriver.set(buildWebDriver(desiredCapabilities));
         this.webDriverWait.set(buildWebDriverWait());
+        this.pages = new Pages(webDriver.get(), webDriverWait.get(), baseUrl);
     }
 
     @Override

--- a/src/test/java/uk/gov/dhsc/htbhf/local/LocalConfiguration.java
+++ b/src/test/java/uk/gov/dhsc/htbhf/local/LocalConfiguration.java
@@ -31,9 +31,12 @@ public class LocalConfiguration {
     @Value("${wiremock.port}")
     private int wiremockPort;
 
+    @Value("${base.url}")
+    private String baseUrl;
+
     @Bean(destroyMethod = "closeDriver")
     public WebDriverWrapper localWebDriverWrapper() {
-        return new LocalWebDriverWrapper(browser, headless, waitTimeoutInSeconds);
+        return new LocalWebDriverWrapper(browser, headless, waitTimeoutInSeconds, baseUrl);
     }
 
     @Bean(destroyMethod = "stop")

--- a/src/test/java/uk/gov/dhsc/htbhf/local/LocalWebDriverWrapper.java
+++ b/src/test/java/uk/gov/dhsc/htbhf/local/LocalWebDriverWrapper.java
@@ -7,6 +7,7 @@ import org.openqa.selenium.firefox.FirefoxDriver;
 import org.openqa.selenium.firefox.FirefoxOptions;
 import org.openqa.selenium.support.ui.WebDriverWait;
 import uk.gov.dhsc.htbhf.WebDriverWrapper;
+import uk.gov.dhsc.htbhf.page.Pages;
 
 /**
  * Controls creation of WebDriver and WebDriverWait for local testing.
@@ -18,13 +19,15 @@ public class LocalWebDriverWrapper implements WebDriverWrapper {
     private final int waitTimeoutInSeconds;
     private final WebDriver webDriver;
     private final WebDriverWait webDriverWait;
+    private final Pages pages;
 
-    public LocalWebDriverWrapper(String browser, boolean headless, int waitTimeoutInSeconds) {
+    public LocalWebDriverWrapper(String browser, boolean headless, int waitTimeoutInSeconds, String baseUrl) {
         this.browser = browser;
         this.headless = headless;
         this.waitTimeoutInSeconds = waitTimeoutInSeconds;
         this.webDriver = buildWebDriver();
         this.webDriverWait = buildWebDriverWait();
+        this.pages = new Pages(webDriver, webDriverWait, baseUrl);
     }
 
     @Override
@@ -35,6 +38,11 @@ public class LocalWebDriverWrapper implements WebDriverWrapper {
     @Override
     public WebDriverWait getWebDriverWait() {
         return webDriverWait;
+    }
+
+    @Override
+    public Pages getPages() {
+        return pages;
     }
 
     @Override

--- a/src/test/java/uk/gov/dhsc/htbhf/page/AreYouPregnantPage.java
+++ b/src/test/java/uk/gov/dhsc/htbhf/page/AreYouPregnantPage.java
@@ -37,8 +37,8 @@ public class AreYouPregnantPage extends SubmittablePage {
     }
 
     @Override
-    String getPageName() {
-        return "are you pregnant";
+    PageName getPageName() {
+        return PageName.ARE_YOU_PREGNANT;
     }
 
     @Override

--- a/src/test/java/uk/gov/dhsc/htbhf/page/BasePage.java
+++ b/src/test/java/uk/gov/dhsc/htbhf/page/BasePage.java
@@ -31,7 +31,7 @@ public abstract class BasePage extends BaseComponent {
 
     abstract String getPath();
 
-    abstract String getPageName();
+    abstract PageName getPageName();
 
     abstract String getPageTitle();
 

--- a/src/test/java/uk/gov/dhsc/htbhf/page/CheckAnswersPage.java
+++ b/src/test/java/uk/gov/dhsc/htbhf/page/CheckAnswersPage.java
@@ -33,8 +33,8 @@ public class CheckAnswersPage extends SubmittablePage {
     }
 
     @Override
-    String getPageName() {
-        return "check answers";
+    PageName getPageName() {
+        return PageName.CHECK_ANSWERS;
     }
 
     @Override

--- a/src/test/java/uk/gov/dhsc/htbhf/page/ChildDateOfBirthPage.java
+++ b/src/test/java/uk/gov/dhsc/htbhf/page/ChildDateOfBirthPage.java
@@ -24,8 +24,8 @@ public class ChildDateOfBirthPage extends SubmittablePage {
     }
 
     @Override
-    String getPageName() {
-        return "enter your childrens dates of birth";
+    PageName getPageName() {
+        return PageName.CHILD_DATE_OF_BIRTH;
     }
 
     @Override

--- a/src/test/java/uk/gov/dhsc/htbhf/page/ConfirmationPage.java
+++ b/src/test/java/uk/gov/dhsc/htbhf/page/ConfirmationPage.java
@@ -22,8 +22,8 @@ public class ConfirmationPage extends BasePage {
     }
 
     @Override
-    String getPageName() {
-        return "confirmation";
+    PageName getPageName() {
+        return PageName.CONFIRMATION;
     }
 
     @Override

--- a/src/test/java/uk/gov/dhsc/htbhf/page/DateOfBirthPage.java
+++ b/src/test/java/uk/gov/dhsc/htbhf/page/DateOfBirthPage.java
@@ -30,8 +30,8 @@ public class DateOfBirthPage extends SubmittablePage {
     }
 
     @Override
-    String getPageName() {
-        return "enter date of birth";
+    PageName getPageName() {
+        return PageName.DATE_OF_BIRTH;
     }
 
     @Override

--- a/src/test/java/uk/gov/dhsc/htbhf/page/DoYouHaveChildrenPage.java
+++ b/src/test/java/uk/gov/dhsc/htbhf/page/DoYouHaveChildrenPage.java
@@ -7,12 +7,12 @@ import uk.gov.dhsc.htbhf.page.component.RadioButton;
 /**
  * Page object for the Do You Have Children page.
  */
-public class DoYouHaveChildren extends SubmittablePage {
+public class DoYouHaveChildrenPage extends SubmittablePage {
 
     private RadioButton yesRadioButton;
     private RadioButton noRadioButton;
 
-    public DoYouHaveChildren(WebDriver webDriver, String baseUrl, WebDriverWait wait) {
+    public DoYouHaveChildrenPage(WebDriver webDriver, String baseUrl, WebDriverWait wait) {
         super(webDriver, baseUrl, wait);
         this.yesRadioButton = new RadioButton(webDriver, wait, RadioButton.YES);
         this.noRadioButton = new RadioButton(webDriver, wait, RadioButton.NO);
@@ -24,8 +24,8 @@ public class DoYouHaveChildren extends SubmittablePage {
     }
 
     @Override
-    String getPageName() {
-        return "do you have children under four years old";
+    PageName getPageName() {
+        return PageName.DO_YOU_HAVE_CHILDREN;
     }
 
     @Override

--- a/src/test/java/uk/gov/dhsc/htbhf/page/EmailAddressPage.java
+++ b/src/test/java/uk/gov/dhsc/htbhf/page/EmailAddressPage.java
@@ -22,8 +22,8 @@ public class EmailAddressPage extends SubmittablePage {
     }
 
     @Override
-    String getPageName() {
-        return "email address";
+    PageName getPageName() {
+        return PageName.EMAIL_ADDRESS;
     }
 
     @Override

--- a/src/test/java/uk/gov/dhsc/htbhf/page/EnterCodePage.java
+++ b/src/test/java/uk/gov/dhsc/htbhf/page/EnterCodePage.java
@@ -24,8 +24,8 @@ public class EnterCodePage extends SubmittablePage {
     }
 
     @Override
-    String getPageName() {
-        return "enter code";
+    PageName getPageName() {
+        return PageName.ENTER_CODE;
     }
 
     @Override

--- a/src/test/java/uk/gov/dhsc/htbhf/page/GuidancePage.java
+++ b/src/test/java/uk/gov/dhsc/htbhf/page/GuidancePage.java
@@ -15,17 +15,11 @@ import static java.util.stream.Collectors.toList;
  */
 public class GuidancePage extends BasePage {
 
-    public static final String APPLY_PAGE = "Apply for Healthy Start";
-
     private GuidancePageMetadata currentPage;
 
-    public GuidancePage(WebDriver webDriver, String baseUrl, WebDriverWait wait, String pageName) {
+    public GuidancePage(WebDriver webDriver, String baseUrl, WebDriverWait wait, PageName pageName) {
         super(webDriver, baseUrl, wait);
         this.currentPage = GuidancePageMetadata.findByName(pageName);
-    }
-
-    public static GuidancePage buildApplyGuidancePage(WebDriver webDriver, String baseUrl, WebDriverWait wait) {
-        return new GuidancePage(webDriver, baseUrl, wait, APPLY_PAGE);
     }
 
     @Override
@@ -34,13 +28,13 @@ public class GuidancePage extends BasePage {
     }
 
     @Override
-    String getPageName() {
+    PageName getPageName() {
         return currentPage.getPageName();
     }
 
     @Override
     String getPageTitle() {
-        return "GOV.UK - " + currentPage.getPageName();
+        return "GOV.UK - " + currentPage.getPageName().getPageName();
     }
 
     public void clickStartButton() {

--- a/src/test/java/uk/gov/dhsc/htbhf/page/GuidancePageMetadata.java
+++ b/src/test/java/uk/gov/dhsc/htbhf/page/GuidancePageMetadata.java
@@ -2,31 +2,29 @@ package uk.gov.dhsc.htbhf.page;
 
 import java.util.Arrays;
 
-import static uk.gov.dhsc.htbhf.page.GuidancePage.APPLY_PAGE;
-
 /**
  * Enum representing metadata about each guidance page. The order of the enums
  * is important and should mirror the order of the pages in the application.
  */
 public enum GuidancePageMetadata {
 
-    HOW_IT_WORKS("How it works", "/"),
-    ELIGIBILITY("Eligibility", "/eligibility"),
-    WHAT_YOU_GET("What you’ll get", "/what-you-get"),
-    WHAT_YOU_CAN_BUY("What you can buy", "/buy"),
-    USING_YOUR_CARD("Using your card", "/using-your-card"),
-    APPLY(APPLY_PAGE, "/apply"),
-    REPORT_A_CHANGE("Report a change", "/report-a-change");
+    HOW_IT_WORKS(PageName.HOW_IT_WORKS, "/"),
+    ELIGIBILITY(PageName.ELIGIBILITY, "/eligibility"),
+    WHAT_YOU_GET(PageName.WHAT_YOU_GET, "/what-you-get"),
+    WHAT_YOU_CAN_BUY(PageName.WHAT_YOU_CAN_BUY, "/buy"),
+    USING_YOUR_CARD(PageName.USING_YOUR_CARD, "/using-your-card"),
+    APPLY(PageName.APPLY, "/apply"),
+    REPORT_A_CHANGE(PageName.REPORT_A_CHANGE, "/report-a-change");
 
-    private String pageName;
+    private PageName pageName;
     private String pagePath;
 
-    GuidancePageMetadata(String pageName, String pagePath) {
+    GuidancePageMetadata(PageName pageName, String pagePath) {
         this.pageName = pageName;
         this.pagePath = pagePath;
     }
 
-    public String getPageName() {
+    public PageName getPageName() {
         return pageName;
     }
 
@@ -34,7 +32,7 @@ public enum GuidancePageMetadata {
         return pagePath;
     }
 
-    public static GuidancePageMetadata findByName(String pageName) {
+    public static GuidancePageMetadata findByName(PageName pageName) {
         return Arrays.stream(GuidancePageMetadata.values())
                 .filter(page -> pageName.equals(page.pageName))
                 .findFirst()

--- a/src/test/java/uk/gov/dhsc/htbhf/page/GuidancePageMetadataTest.java
+++ b/src/test/java/uk/gov/dhsc/htbhf/page/GuidancePageMetadataTest.java
@@ -9,23 +9,17 @@ import static org.assertj.core.api.Assertions.catchThrowableOfType;
 
 class GuidancePageMetadataTest {
 
-    @CsvSource({"How it works, HOW_IT_WORKS",
-            "Eligibility, ELIGIBILITY",
-            "What you’ll get, WHAT_YOU_GET",
-            "What you can buy, WHAT_YOU_CAN_BUY",
-            "Using your card, USING_YOUR_CARD",
-            "Apply for Healthy Start, APPLY",
-            "Report a change, REPORT_A_CHANGE"
+    @CsvSource({"HOW_IT_WORKS, HOW_IT_WORKS",
+            "ELIGIBILITY, ELIGIBILITY",
+            "WHAT_YOU_GET, WHAT_YOU_GET",
+            "WHAT_YOU_CAN_BUY, WHAT_YOU_CAN_BUY",
+            "USING_YOUR_CARD, USING_YOUR_CARD",
+            "APPLY, APPLY",
+            "REPORT_A_CHANGE, REPORT_A_CHANGE"
     })
     @ParameterizedTest
-    void shouldFindByName(String pageName, GuidancePageMetadata expectedGuidancePageMetadata) {
+    void shouldFindByName(PageName pageName, GuidancePageMetadata expectedGuidancePageMetadata) {
         assertThat(GuidancePageMetadata.findByName(pageName)).isEqualTo(expectedGuidancePageMetadata);
-    }
-
-    @Test
-    void shouldThrowErrorWhenPageNotFoundByName() {
-        IllegalArgumentException exception = catchThrowableOfType(() -> GuidancePageMetadata.findByName("foo"), IllegalArgumentException.class);
-        assertThat(exception).hasMessage("No page metadata found for page with name: foo");
     }
 
     @Test

--- a/src/test/java/uk/gov/dhsc/htbhf/page/ManualAddressPage.java
+++ b/src/test/java/uk/gov/dhsc/htbhf/page/ManualAddressPage.java
@@ -35,8 +35,8 @@ public class ManualAddressPage extends SubmittablePage {
     }
 
     @Override
-    String getPageName() {
-        return "address";
+    PageName getPageName() {
+        return PageName.MANUAL_ADDRESS;
     }
 
     @Override

--- a/src/test/java/uk/gov/dhsc/htbhf/page/NamePage.java
+++ b/src/test/java/uk/gov/dhsc/htbhf/page/NamePage.java
@@ -27,8 +27,8 @@ public class NamePage extends SubmittablePage {
     }
 
     @Override
-    String getPageName() {
-        return "enter name";
+    PageName getPageName() {
+        return PageName.NAME;
     }
 
     @Override

--- a/src/test/java/uk/gov/dhsc/htbhf/page/NationalInsuranceNumberPage.java
+++ b/src/test/java/uk/gov/dhsc/htbhf/page/NationalInsuranceNumberPage.java
@@ -23,8 +23,8 @@ public class NationalInsuranceNumberPage extends SubmittablePage {
     }
 
     @Override
-    String getPageName() {
-        return "enter national insurance number";
+    PageName getPageName() {
+        return PageName.NATIONAL_INSURANCE_NUMBER;
     }
 
     @Override

--- a/src/test/java/uk/gov/dhsc/htbhf/page/PageName.java
+++ b/src/test/java/uk/gov/dhsc/htbhf/page/PageName.java
@@ -1,0 +1,49 @@
+package uk.gov.dhsc.htbhf.page;
+
+import java.util.Arrays;
+
+/**
+ * Enum of all the page names
+ */
+public enum PageName {
+
+    ARE_YOU_PREGNANT("are you pregnant"),
+    CHECK_ANSWERS("check answers"),
+    CHILD_DATE_OF_BIRTH("enter your childrens dates of birth"),
+    CONFIRMATION("confirmation"),
+    DATE_OF_BIRTH("enter date of birth"),
+    DO_YOU_HAVE_CHILDREN("do you have children under four years old"),
+    EMAIL_ADDRESS("email address"),
+    ENTER_CODE("enter code"),
+    MANUAL_ADDRESS("address"),
+    NAME("enter name"),
+    NATIONAL_INSURANCE_NUMBER("enter national insurance number"),
+    PHONE_NUMBER("phone number"),
+    SCOTLAND("do you live in Scotland"),
+    SEND_CODE("send code"),
+    TERMS_AND_CONDITIONS("terms and conditions"),
+    HOW_IT_WORKS("How it works"),
+    ELIGIBILITY("Eligibility"),
+    WHAT_YOU_GET("What you’ll get"),
+    WHAT_YOU_CAN_BUY("What you can buy"),
+    USING_YOUR_CARD("Using your card"),
+    APPLY("Apply for Healthy Start"),
+    REPORT_A_CHANGE("Report a change");
+
+    private String pageName;
+
+    PageName(String pageName) {
+        this.pageName = pageName;
+    }
+
+    public String getPageName() {
+        return this.pageName;
+    }
+
+    public static PageName getPageName(String pageName) {
+        return Arrays.stream(PageName.values())
+                .filter(page -> pageName.equals(page.pageName))
+                .findFirst()
+                .orElseThrow(() -> new IllegalArgumentException("No page name found for name: " + pageName));
+    }
+}

--- a/src/test/java/uk/gov/dhsc/htbhf/page/PageNameTest.java
+++ b/src/test/java/uk/gov/dhsc/htbhf/page/PageNameTest.java
@@ -1,0 +1,46 @@
+package uk.gov.dhsc.htbhf.page;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.catchThrowableOfType;
+
+class PageNameTest {
+
+    @CsvSource({
+            "ARE_YOU_PREGNANT, are you pregnant",
+            "CHECK_ANSWERS, check answers",
+            "CHILD_DATE_OF_BIRTH, enter your childrens dates of birth",
+            "CONFIRMATION, confirmation",
+            "DATE_OF_BIRTH, enter date of birth",
+            "DO_YOU_HAVE_CHILDREN, do you have children under four years old",
+            "EMAIL_ADDRESS, email address",
+            "ENTER_CODE, enter code",
+            "MANUAL_ADDRESS, address",
+            "NAME, enter name",
+            "NATIONAL_INSURANCE_NUMBER, enter national insurance number",
+            "PHONE_NUMBER, phone number",
+            "SCOTLAND, do you live in Scotland",
+            "SEND_CODE, send code",
+            "TERMS_AND_CONDITIONS, terms and conditions",
+            "HOW_IT_WORKS, How it works",
+            "ELIGIBILITY, Eligibility",
+            "WHAT_YOU_GET, What you’ll get",
+            "WHAT_YOU_CAN_BUY, What you can buy",
+            "USING_YOUR_CARD, Using your card",
+            "APPLY, Apply for Healthy Start",
+            "REPORT_A_CHANGE, Report a change"
+    })
+    @ParameterizedTest
+    void shouldGetPageName(PageName pageName, String name) {
+        assertThat(PageName.getPageName(name)).isEqualTo(pageName);
+    }
+
+    @Test
+    void shouldFailToGetPageName() {
+        Throwable thrown = catchThrowableOfType(() -> PageName.getPageName("foo"), IllegalArgumentException.class);
+        assertThat(thrown).hasMessage("No page name found for name: foo");
+    }
+}

--- a/src/test/java/uk/gov/dhsc/htbhf/page/Pages.java
+++ b/src/test/java/uk/gov/dhsc/htbhf/page/Pages.java
@@ -1,0 +1,130 @@
+package uk.gov.dhsc.htbhf.page;
+
+import org.openqa.selenium.WebDriver;
+import org.openqa.selenium.support.ui.WebDriverWait;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+/**
+ * Store for all the pages in the application so we can get and navigate to them easily.
+ */
+public class Pages {
+
+    private WebDriver webDriver;
+    private WebDriverWait webDriverWait;
+    private String baseUrl;
+    private List<BasePage> pages = new ArrayList<>();
+
+    public Pages(WebDriver webDriver, WebDriverWait webDriverWait, String baseUrl) {
+        this.webDriver = webDriver;
+        this.webDriverWait = webDriverWait;
+        this.baseUrl = baseUrl;
+        initPages();
+    }
+
+    private void initPages() {
+        pages.add(new AreYouPregnantPage(webDriver, baseUrl, webDriverWait));
+        pages.add(new CheckAnswersPage(webDriver, baseUrl, webDriverWait));
+        pages.add(new ChildDateOfBirthPage(webDriver, baseUrl, webDriverWait));
+        pages.add(new ConfirmationPage(webDriver, baseUrl, webDriverWait));
+        pages.add(new DateOfBirthPage(webDriver, baseUrl, webDriverWait));
+        pages.add(new DoYouHaveChildrenPage(webDriver, baseUrl, webDriverWait));
+        pages.add(new EmailAddressPage(webDriver, baseUrl, webDriverWait));
+        pages.add(new EnterCodePage(webDriver, baseUrl, webDriverWait));
+        pages.add(new ManualAddressPage(webDriver, baseUrl, webDriverWait));
+        pages.add(new NamePage(webDriver, baseUrl, webDriverWait));
+        pages.add(new NationalInsuranceNumberPage(webDriver, baseUrl, webDriverWait));
+        pages.add(new PhoneNumberPage(webDriver, baseUrl, webDriverWait));
+        pages.add(new ScotlandPage(webDriver, baseUrl, webDriverWait));
+        pages.add(new SendCodePage(webDriver, baseUrl, webDriverWait));
+        pages.add(new TermsAndConditionsPage(webDriver, baseUrl, webDriverWait));
+        //Guidance pages
+        Arrays.stream(GuidancePageMetadata.values()).forEach(
+                guidancePageMetadata -> pages.add(new GuidancePage(webDriver, baseUrl, webDriverWait, guidancePageMetadata.getPageName()))
+        );
+    }
+
+    public BasePage getAndWaitForPageByName(PageName name) {
+        BasePage page = getPageByName(name);
+        page.waitForPageToLoad();
+        return page;
+    }
+
+    public BasePage getPageByName(PageName name) {
+        return pages.stream()
+                .filter(basePage -> basePage.getPageName().equals(name))
+                .findFirst()
+                .orElseThrow(() -> new IllegalArgumentException("Could not find page with name: " + name));
+    }
+
+    public CheckAnswersPage getCheckAnswersPage() {
+        return (CheckAnswersPage) getAndWaitForPageByName(PageName.CHECK_ANSWERS);
+    }
+
+    public EnterCodePage getEnterCodePage() {
+        return (EnterCodePage) getAndWaitForPageByName(PageName.ENTER_CODE);
+    }
+
+    public SendCodePage getSendCodePage() {
+        return (SendCodePage) getAndWaitForPageByName(PageName.SEND_CODE);
+    }
+
+    public EmailAddressPage getEmailAddressPage() {
+        return (EmailAddressPage) getAndWaitForPageByName(PageName.EMAIL_ADDRESS);
+    }
+
+    public PhoneNumberPage getPhoneNumberPage() {
+        return (PhoneNumberPage) getAndWaitForPageByName(PageName.PHONE_NUMBER);
+    }
+
+    public ManualAddressPage getManualAddressPage() {
+        return (ManualAddressPage) getAndWaitForPageByName(PageName.MANUAL_ADDRESS);
+    }
+
+    public NationalInsuranceNumberPage getNationalInsuranceNumberPage() {
+        return (NationalInsuranceNumberPage) getAndWaitForPageByName(PageName.NATIONAL_INSURANCE_NUMBER);
+    }
+
+    public NamePage getNamePage() {
+        return (NamePage) getAndWaitForPageByName(PageName.NAME);
+    }
+
+    public AreYouPregnantPage getAreYouPregnantPage() {
+        return (AreYouPregnantPage) getAndWaitForPageByName(PageName.ARE_YOU_PREGNANT);
+    }
+
+    public ChildDateOfBirthPage getChildDateOfBirthPage() {
+        return (ChildDateOfBirthPage) getAndWaitForPageByName(PageName.CHILD_DATE_OF_BIRTH);
+    }
+
+    public DoYouHaveChildrenPage getDoYouHaveChildrenPage() {
+        return (DoYouHaveChildrenPage) getAndWaitForPageByName(PageName.DO_YOU_HAVE_CHILDREN);
+    }
+
+    public DateOfBirthPage getDateOfBirthPage() {
+        return (DateOfBirthPage) getAndWaitForPageByName(PageName.DATE_OF_BIRTH);
+    }
+
+    public ScotlandPage getScotlandPage() {
+        return (ScotlandPage) getAndWaitForPageByName(PageName.SCOTLAND);
+    }
+
+    public TermsAndConditionsPage getTermsAndConditionsPage() {
+        return (TermsAndConditionsPage) getAndWaitForPageByName(PageName.TERMS_AND_CONDITIONS);
+    }
+
+    public ConfirmationPage getConfirmationPage() {
+        return (ConfirmationPage) getAndWaitForPageByName(PageName.CONFIRMATION);
+    }
+
+    public GuidancePage getGuidancePage(PageName pageName) {
+        return (GuidancePage) getAndWaitForPageByName(pageName);
+    }
+
+    public GuidancePage getGuidancePageNoWait(PageName pageName) {
+        return (GuidancePage) getPageByName(pageName);
+    }
+
+}

--- a/src/test/java/uk/gov/dhsc/htbhf/page/PhoneNumberPage.java
+++ b/src/test/java/uk/gov/dhsc/htbhf/page/PhoneNumberPage.java
@@ -22,8 +22,8 @@ public class PhoneNumberPage extends SubmittablePage {
     }
 
     @Override
-    String getPageName() {
-        return "phone number";
+    PageName getPageName() {
+        return PageName.PHONE_NUMBER;
     }
 
     @Override

--- a/src/test/java/uk/gov/dhsc/htbhf/page/ScotlandPage.java
+++ b/src/test/java/uk/gov/dhsc/htbhf/page/ScotlandPage.java
@@ -24,8 +24,8 @@ public class ScotlandPage extends SubmittablePage {
     }
 
     @Override
-    String getPageName() {
-        return "do you live in Scotland";
+    PageName getPageName() {
+        return PageName.SCOTLAND;
     }
 
     @Override

--- a/src/test/java/uk/gov/dhsc/htbhf/page/SendCodePage.java
+++ b/src/test/java/uk/gov/dhsc/htbhf/page/SendCodePage.java
@@ -26,8 +26,8 @@ public class SendCodePage extends SubmittablePage {
     }
 
     @Override
-    String getPageName() {
-        return "send code";
+    PageName getPageName() {
+        return PageName.SEND_CODE;
     }
 
     @Override

--- a/src/test/java/uk/gov/dhsc/htbhf/page/TermsAndConditionsPage.java
+++ b/src/test/java/uk/gov/dhsc/htbhf/page/TermsAndConditionsPage.java
@@ -20,8 +20,8 @@ public class TermsAndConditionsPage extends SubmittablePage {
     }
 
     @Override
-    String getPageName() {
-        return "terms and conditions";
+    PageName getPageName() {
+        return PageName.TERMS_AND_CONDITIONS;
     }
 
     @Override

--- a/src/test/java/uk/gov/dhsc/htbhf/steps/BaseSteps.java
+++ b/src/test/java/uk/gov/dhsc/htbhf/steps/BaseSteps.java
@@ -6,6 +6,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import uk.gov.dhsc.htbhf.TestResultHandler;
 import uk.gov.dhsc.htbhf.WebDriverWrapper;
+import uk.gov.dhsc.htbhf.page.Pages;
 import uk.gov.dhsc.htbhf.utils.WireMockManager;
 
 /**
@@ -39,6 +40,10 @@ public abstract class BaseSteps {
 
     protected WebDriverWait getWebDriverWait() {
         return webDriverWrapper.getWebDriverWait();
+    }
+
+    protected Pages getPages() {
+        return webDriverWrapper.getPages();
     }
 
 }

--- a/src/test/java/uk/gov/dhsc/htbhf/steps/CheckDetailsSteps.java
+++ b/src/test/java/uk/gov/dhsc/htbhf/steps/CheckDetailsSteps.java
@@ -18,8 +18,7 @@ public class CheckDetailsSteps extends BaseSteps {
 
     @Then("^I am shown the check answers page with correct page content$")
     public void verifyCheckDetailsPageCorrect() {
-        checkAnswersPage = new CheckAnswersPage(getWebDriver(), baseUrl, getWebDriverWait());
-        checkAnswersPage.waitForPageToLoad();
+        checkAnswersPage = getPages().getCheckAnswersPage();
         assertThat(checkAnswersPage.getH1Text())
                 .as("expected check page H1 text to not be empty")
                 .isNotBlank();

--- a/src/test/java/uk/gov/dhsc/htbhf/steps/CompleteFlowSteps.java
+++ b/src/test/java/uk/gov/dhsc/htbhf/steps/CompleteFlowSteps.java
@@ -14,7 +14,7 @@ public class CompleteFlowSteps extends BaseSteps {
     private GuidancePage guidancePage;
     private ScotlandPage scotlandPage;
     private DateOfBirthPage dateOfBirthPage;
-    private DoYouHaveChildren doYouHaveChildren;
+    private DoYouHaveChildrenPage doYouHaveChildrenPage;
     private ChildDateOfBirthPage childDateOfBirthPage;
     private AreYouPregnantPage areYouPregnantPage;
     private NamePage namePage;
@@ -28,7 +28,7 @@ public class CompleteFlowSteps extends BaseSteps {
 
     @When("^I complete the application with valid details for a pregnant woman")
     public void completeTheApplicationAsAPregnantWoman() {
-        guidancePage = GuidancePage.buildApplyGuidancePage(getWebDriver(), baseUrl, getWebDriverWait());
+        guidancePage = getPages().getGuidancePage(PageName.APPLY);
         guidancePage.clickStartButton();
         enterDoYouLiveInScotlandNoAndSubmit();
         enterDateOfBirthAndSubmit();
@@ -45,8 +45,7 @@ public class CompleteFlowSteps extends BaseSteps {
     }
 
     private void enterConfirmationCodeAndSubmit() {
-        enterCodePage = new EnterCodePage(getWebDriver(), baseUrl, getWebDriverWait());
-        enterCodePage.waitForPageToLoad();
+        enterCodePage = getPages().getEnterCodePage();
         confirmationCodePage = new ConfirmationCodePage(getWebDriver(), sessionDetailsUrl);
         String confirmationCode = confirmationCodePage.getConfirmationCodeForSession();
         enterCodePage.open();
@@ -55,29 +54,25 @@ public class CompleteFlowSteps extends BaseSteps {
     }
 
     private void selectTextOnSendCode() {
-        sendCodePage = new SendCodePage(getWebDriver(), baseUrl, getWebDriverWait());
-        sendCodePage.waitForPageToLoad();
+        sendCodePage = getPages().getSendCodePage();
         sendCodePage.selectText();
         sendCodePage.clickContinue();
     }
 
     private void enterEmailAddress() {
-        emailAddressPage = new EmailAddressPage(getWebDriver(), baseUrl, getWebDriverWait());
-        emailAddressPage.waitForPageToLoad();
+        emailAddressPage = getPages().getEmailAddressPage();
         emailAddressPage.enterEmailAddress(EMAIL_ADDRESS);
         emailAddressPage.clickContinue();
     }
 
     private void enterPhoneNumber() {
-        phoneNumberPage = new PhoneNumberPage(getWebDriver(), baseUrl, getWebDriverWait());
-        phoneNumberPage.waitForPageToLoad();
+        phoneNumberPage = getPages().getPhoneNumberPage();
         phoneNumberPage.enterPhoneNumber(PHONE_NUMBER);
         phoneNumberPage.clickContinue();
     }
 
     private void enterManualAddress() {
-        manualAddressPage = new ManualAddressPage(getWebDriver(), baseUrl, getWebDriverWait());
-        manualAddressPage.waitForPageToLoad();
+        manualAddressPage = getPages().getManualAddressPage();
         manualAddressPage.enterAddressLine1(ADDRESS_LINE_1);
         manualAddressPage.enterAddressLine2(ADDRESS_LINE_2);
         manualAddressPage.enterTownOrCity(TOWN);
@@ -87,44 +82,38 @@ public class CompleteFlowSteps extends BaseSteps {
     }
 
     private void enterNino() {
-        nationalInsuranceNumberPage = new NationalInsuranceNumberPage(getWebDriver(), baseUrl, getWebDriverWait());
-        nationalInsuranceNumberPage.waitForPageToLoad();
+        nationalInsuranceNumberPage = getPages().getNationalInsuranceNumberPage();
         nationalInsuranceNumberPage.enterNino(generateEligibleNino());
         nationalInsuranceNumberPage.clickContinue();
     }
 
     private void enterName() {
-        namePage = new NamePage(getWebDriver(), baseUrl, getWebDriverWait());
-        namePage.waitForPageToLoad();
+        namePage = getPages().getNamePage();
         namePage.enterName(FIRST_NAME, LAST_NAME);
         namePage.clickContinue();
     }
 
     private void selectYesOnPregnancyPage() {
-        areYouPregnantPage = new AreYouPregnantPage(getWebDriver(), baseUrl, getWebDriverWait());
-        areYouPregnantPage.waitForPageToLoad();
+        areYouPregnantPage = getPages().getAreYouPregnantPage();
         areYouPregnantPage.selectYes();
         areYouPregnantPage.enterExpectedDeliveryDate(2);
         areYouPregnantPage.clickContinue();
     }
 
     private void enterOneChildsDateOfBirth() {
-        childDateOfBirthPage = new ChildDateOfBirthPage(getWebDriver(), baseUrl, getWebDriverWait());
-        childDateOfBirthPage.waitForPageToLoad();
+        childDateOfBirthPage = getPages().getChildDateOfBirthPage();
         childDateOfBirthPage.enterChild3OrUnderDetails(1);
         childDateOfBirthPage.clickContinue();
     }
 
     private void enterDoYouHaveChildrenYesAndSubmit() {
-        doYouHaveChildren = new DoYouHaveChildren(getWebDriver(), baseUrl, getWebDriverWait());
-        doYouHaveChildren.waitForPageToLoad();
-        doYouHaveChildren.selectYesRadioButton();
-        doYouHaveChildren.clickContinue();
+        doYouHaveChildrenPage = getPages().getDoYouHaveChildrenPage();
+        doYouHaveChildrenPage.selectYesRadioButton();
+        doYouHaveChildrenPage.clickContinue();
     }
 
     private void enterDateOfBirthAndSubmit() {
-        dateOfBirthPage = new DateOfBirthPage(getWebDriver(), baseUrl, getWebDriverWait());
-        dateOfBirthPage.waitForPageToLoad();
+        dateOfBirthPage = getPages().getDateOfBirthPage();
         dateOfBirthPage.getDayInputField().enterValue(DOB_DAY);
         dateOfBirthPage.getMonthInputField().enterValue(DOB_MONTH);
         dateOfBirthPage.getYearInputField().enterValue(DOB_YEAR);
@@ -132,8 +121,7 @@ public class CompleteFlowSteps extends BaseSteps {
     }
 
     private void enterDoYouLiveInScotlandNoAndSubmit() {
-        scotlandPage = new ScotlandPage(getWebDriver(), baseUrl, getWebDriverWait());
-        scotlandPage.waitForPageToLoad();
+        scotlandPage = getPages().getScotlandPage();
         scotlandPage.selectNoRadioButton();
         scotlandPage.clickContinue();
     }

--- a/src/test/java/uk/gov/dhsc/htbhf/steps/ConfirmDetailsSteps.java
+++ b/src/test/java/uk/gov/dhsc/htbhf/steps/ConfirmDetailsSteps.java
@@ -15,8 +15,7 @@ public class ConfirmDetailsSteps extends BaseSteps {
 
     @Then("/^I am shown a successful confirmation page$/")
     public void iAmShownASuccessfulConfirmationPage() {
-        confirmationPage = new ConfirmationPage(getWebDriver(), baseUrl, getWebDriverWait());
-        confirmationPage.waitForPageToLoad();
+        confirmationPage = getPages().getConfirmationPage();
         checkAllPageContentIsPresentAndCorrect();
         wireMockManager.resetWireMockStubs();
     }

--- a/src/test/java/uk/gov/dhsc/htbhf/steps/GuidanceSteps.java
+++ b/src/test/java/uk/gov/dhsc/htbhf/steps/GuidanceSteps.java
@@ -5,6 +5,7 @@ import io.cucumber.java.en.Then;
 import io.cucumber.java.en.When;
 import org.openqa.selenium.WebElement;
 import uk.gov.dhsc.htbhf.page.GuidancePage;
+import uk.gov.dhsc.htbhf.page.PageName;
 
 import java.util.List;
 
@@ -19,13 +20,13 @@ public class GuidanceSteps extends BaseSteps {
 
     @Given("^I am on the first page of the application")
     public void givenIAmOnTheFirstPageOfTheApplication() {
-        guidancePage = GuidancePage.buildApplyGuidancePage(getWebDriver(), baseUrl, getWebDriverWait());
+        guidancePage = getPages().getGuidancePageNoWait(PageName.APPLY);
         guidancePage.open();
     }
 
     @When("^I open the (.*) guidance page$")
     public void openGuidancePage(String pageName) {
-        guidancePage = new GuidancePage(getWebDriver(), baseUrl, getWebDriverWait(), pageName);
+        guidancePage = getPages().getGuidancePageNoWait(PageName.getPageName(pageName));
         guidancePage.open();
     }
 

--- a/src/test/java/uk/gov/dhsc/htbhf/steps/TermsAndConditionsSteps.java
+++ b/src/test/java/uk/gov/dhsc/htbhf/steps/TermsAndConditionsSteps.java
@@ -15,14 +15,13 @@ public class TermsAndConditionsSteps extends BaseSteps {
     @When("/^I accept the terms and conditions and submit my application$/")
     public void acceptTermsAndConditionsAndSubmitApplication() {
         wireMockManager.setupWireMockMappingsWithStatus("ELIGIBLE");
-        checkAnswersPage = new CheckAnswersPage(getWebDriver(), baseUrl, getWebDriverWait());
+        checkAnswersPage = getPages().getCheckAnswersPage();
         checkAnswersPage.clickContinue();
         acceptTsAndCsAndSubmitApplication();
     }
 
     private void acceptTsAndCsAndSubmitApplication() {
-        termsAndConditionsPage = new TermsAndConditionsPage(getWebDriver(), baseUrl, getWebDriverWait());
-        termsAndConditionsPage.waitForPageToLoad();
+        termsAndConditionsPage = getPages().getTermsAndConditionsPage();
         termsAndConditionsPage.clickAcceptTermsAndConditionsCheckBox();
         termsAndConditionsPage.clickContinue();
     }


### PR DESCRIPTION
This is in preparation for the navigation steps and feature which is first on the list of acceptance tests to complete as this will enable all the other features.

The amount of change looks worse than it is because I created an enum for the page names so had up do a small update to every page object.