### PR TITLE
Create GenericPage and GenericSteps so we can have step definitions that we can reuse.

### DIFF
--- a/src/test/java/uk/gov/dhsc/htbhf/page/GenericPage.java
+++ b/src/test/java/uk/gov/dhsc/htbhf/page/GenericPage.java
@@ -1,0 +1,30 @@
+package uk.gov.dhsc.htbhf.page;
+
+import org.openqa.selenium.WebDriver;
+import org.openqa.selenium.support.ui.WebDriverWait;
+
+/**
+ * A GenericPage object which can be used to have generic access to any submittable page's
+ * functionality.
+ */
+public class GenericPage extends SubmittablePage {
+
+    protected GenericPage(WebDriver webDriver, String baseUrl, WebDriverWait wait) {
+        super(webDriver, baseUrl, wait);
+    }
+
+    @Override
+    String getPath() {
+        throw new UnsupportedOperationException("Should not be getting the path from Generic page");
+    }
+
+    @Override
+    PageName getPageName() {
+        throw new UnsupportedOperationException("Should not be getting the page name from Generic page");
+    }
+
+    @Override
+    String getPageTitle() {
+        throw new UnsupportedOperationException("Should not be getting the page title from Generic page");
+    }
+}

--- a/src/test/java/uk/gov/dhsc/htbhf/page/Pages.java
+++ b/src/test/java/uk/gov/dhsc/htbhf/page/Pages.java
@@ -16,12 +16,15 @@ public class Pages {
     private WebDriverWait webDriverWait;
     private String baseUrl;
     private List<BasePage> pages = new ArrayList<>();
+    private GenericPage genericPage;
 
     public Pages(WebDriver webDriver, WebDriverWait webDriverWait, String baseUrl) {
         this.webDriver = webDriver;
         this.webDriverWait = webDriverWait;
         this.baseUrl = baseUrl;
         initPages();
+        //We specifically don't add the GenericPage to the List as it doesn't have a PageName
+        this.genericPage = new GenericPage(webDriver, baseUrl, webDriverWait);
     }
 
     private void initPages() {
@@ -130,6 +133,10 @@ public class Pages {
 
     public GuidancePage getGuidancePageNoWait(PageName pageName) {
         return (GuidancePage) getPageByName(pageName);
+    }
+
+    public GenericPage getGenericPage() {
+        return genericPage;
     }
 
 }

--- a/src/test/java/uk/gov/dhsc/htbhf/steps/AreYouPregnantSteps.java
+++ b/src/test/java/uk/gov/dhsc/htbhf/steps/AreYouPregnantSteps.java
@@ -28,18 +28,6 @@ public class AreYouPregnantSteps extends CommonSteps {
         areYouPregnantPage.selectYes();
     }
 
-    @When("^I do not select an option$")
-    public void whenIDoNotSelectAnOption() {
-        // Specifically does nothing
-    }
-
-    //TODO MRS 09/09/2019: Create a GenericSteps class where methods like this can be shared.
-    @When("^I click continue$")
-    public void whenIClickContinue() {
-        AreYouPregnantPage areYouPregnantPage = getPages().getAreYouPregnantPage();
-        areYouPregnantPage.clickContinue();
-    }
-
     @When("^I enter text in the expected delivery date fields")
     public void enterTextInExpectedDeliveryDateFields() {
         AreYouPregnantPage areYouPregnantPage = getPages().getAreYouPregnantPage();

--- a/src/test/java/uk/gov/dhsc/htbhf/steps/GenericSteps.java
+++ b/src/test/java/uk/gov/dhsc/htbhf/steps/GenericSteps.java
@@ -1,0 +1,24 @@
+package uk.gov.dhsc.htbhf.steps;
+
+import io.cucumber.java.en.When;
+import uk.gov.dhsc.htbhf.page.GenericPage;
+
+/**
+ * Contains steps which can be run from a number of different pages. We need to have this because we are not
+ * allowed to have one class which defines steps extend another which defines steps, so these step definitions
+ * need to be in their own step definition class.
+ */
+public class GenericSteps extends CommonSteps {
+
+    @When("^I do not select an option$")
+    public void whenIDoNotSelectAnOption() {
+        // Specifically does nothing
+    }
+
+    @When("^I click continue$")
+    public void whenIClickContinue() {
+        GenericPage genericPage = getPages().getGenericPage();
+        genericPage.clickContinue();
+    }
+
+}


### PR DESCRIPTION
Created a `GenericPage` object which is slightly different to the other pages in how it is stored in `Pages`, feels a bit clunky but couldn't think of a different way to do it - I guess we can iterate on this as we use it more.

The main thing is that we can now define steps that can be reused as they can use the `GenericPage` object.