### PR TITLE
Make methods in BaseComponent be protected - they should only be used…

### DIFF
--- a/src/test/java/uk/gov/dhsc/htbhf/page/BasePage.java
+++ b/src/test/java/uk/gov/dhsc/htbhf/page/BasePage.java
@@ -86,4 +86,21 @@ public abstract class BasePage extends BaseComponent {
         return pageError.getText();
     }
 
+    public String getFieldErrorText(String fieldErrorId) {
+        WebElement fieldError = findById(fieldErrorId);
+        return getVisibleTextFromFieldError(fieldError);
+    }
+
+    public String getErrorLinkText(String errorLinkCss) {
+        WebElement errorLink = findByCss(errorLinkCss);
+        return errorLink.getText();
+    }
+
+    private String getVisibleTextFromFieldError(WebElement errorElement) {
+        String fullErrorText = errorElement.getText();
+        WebElement hiddenError = errorElement.findElement(By.className("govuk-visually-hidden"));
+        String hiddenErrorText = hiddenError.getText();
+        return fullErrorText.replace(hiddenErrorText, "").trim();
+    }
+
 }

--- a/src/test/java/uk/gov/dhsc/htbhf/page/component/BaseComponent.java
+++ b/src/test/java/uk/gov/dhsc/htbhf/page/component/BaseComponent.java
@@ -21,32 +21,31 @@ public abstract class BaseComponent {
         this.webDriverWait = webDriverWait;
     }
 
-    //TODO MRS 10/09/2019: All the find methods should become protected so they can only be used by components and not steps.
-    public WebElement findByClassName(String className) {
+    protected WebElement findByClassName(String className) {
         return webDriver.findElement(By.className(className));
     }
 
-    public WebElement findByCss(String cssSelector) {
+    protected WebElement findByCss(String cssSelector) {
         return webDriver.findElement(By.cssSelector(cssSelector));
     }
 
-    public WebElement findById(String id) {
+    protected WebElement findById(String id) {
         return webDriver.findElement(By.id(id));
     }
 
-    public List<WebElement> findAllByCss(String cssSelector) {
+    protected List<WebElement> findAllByCss(String cssSelector) {
         return webDriver.findElements(By.cssSelector(cssSelector));
     }
 
-    public List<WebElement> findAllById(String id) {
+    protected List<WebElement> findAllById(String id) {
         return webDriver.findElements(By.id(id));
     }
 
-    public List<WebElement> findAllByXpath(String xpathExpression) {
+    protected List<WebElement> findAllByXpath(String xpathExpression) {
         return webDriver.findElements(By.xpath(xpathExpression));
     }
 
-    public void click(By by) {
+    protected void click(By by) {
         webDriverWait.until(ExpectedConditions.elementToBeClickable(by));
         WebElement element = webDriver.findElement(by);
         element.click();

--- a/src/test/java/uk/gov/dhsc/htbhf/steps/BaseSteps.java
+++ b/src/test/java/uk/gov/dhsc/htbhf/steps/BaseSteps.java
@@ -1,8 +1,6 @@
 package uk.gov.dhsc.htbhf.steps;
 
-import org.openqa.selenium.By;
 import org.openqa.selenium.WebDriver;
-import org.openqa.selenium.WebElement;
 import org.openqa.selenium.support.ui.WebDriverWait;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
@@ -51,7 +49,6 @@ public abstract class BaseSteps {
         return webDriverWrapper.getPages();
     }
 
-
     protected void assertErrorHeaderTextPresent(BasePage basePage) {
         basePage.waitForPageToLoad();
         String errorHeader = basePage.getPageErrorHeaderText();
@@ -59,21 +56,11 @@ public abstract class BaseSteps {
     }
 
     protected void assertFieldErrorAndLinkTextPresentAndCorrect(BasePage basePage, String fieldErrorId, String errorLinkCss, String expectedErrorMessage) {
-        WebElement fieldError = basePage.findById(fieldErrorId);
-        String fieldErrorText = getVisibleTextFromFieldError(fieldError);
-
-        WebElement errorLink = basePage.findByCss(errorLinkCss);
-        String errorLinkText = errorLink.getText();
+        String fieldErrorText = basePage.getFieldErrorText(fieldErrorId);
+        String errorLinkText = basePage.getErrorLinkText(errorLinkCss);
 
         assertThat(fieldErrorText).isEqualTo(expectedErrorMessage);
         assertThat(errorLinkText).isEqualTo(expectedErrorMessage);
-    }
-
-    private String getVisibleTextFromFieldError(WebElement errorElement) {
-        String fullErrorText = errorElement.getText();
-        WebElement hiddenError = errorElement.findElement(By.className("govuk-visually-hidden"));
-        String hiddenErrorText = hiddenError.getText();
-        return fullErrorText.replace(hiddenErrorText, "").trim();
     }
 
 }


### PR DESCRIPTION
… by components/pages.

Minor PR created from spotting that methods in BaseComponent were being used directly in Step classes, which shouldn't be the case. This resulted in some method needing to be moved from BaseSteps to BasePage.