### PR TITLE
Feature/address lookup default flow

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -42,7 +42,6 @@ dependencies {
     implementation "org.springframework:spring-context:${springVersion}"
     implementation "org.springframework:spring-beans:${springVersion}"
     implementation "org.springframework.retry:spring-retry:1.2.4.RELEASE"
-    implementation "javax.annotation:javax.annotation-api:1.3.2"
 
     testImplementation "org.junit.jupiter:junit-jupiter-engine:${junitVersion}"
     testImplementation "org.junit.jupiter:junit-jupiter-api:${junitVersion}"

--- a/src/test/java/uk/gov/dhsc/htbhf/browserstack/BrowserStackConfiguration.java
+++ b/src/test/java/uk/gov/dhsc/htbhf/browserstack/BrowserStackConfiguration.java
@@ -29,7 +29,7 @@ public class BrowserStackConfiguration {
     @Value("${base.url}")
     private String baseUrl;
 
-    @Value("${FEATURE_TOGGLES}")
+    @Value("${FEATURE_TOGGLES:}")
     private String featureToggles;
 
     @Bean

--- a/src/test/java/uk/gov/dhsc/htbhf/local/LocalConfiguration.java
+++ b/src/test/java/uk/gov/dhsc/htbhf/local/LocalConfiguration.java
@@ -35,7 +35,7 @@ public class LocalConfiguration {
     @Value("${base.url}")
     private String baseUrl;
 
-    @Value("${FEATURE_TOGGLES}")
+    @Value("${FEATURE_TOGGLES:}")
     private String featureToggles;
 
     @Bean()

--- a/src/test/java/uk/gov/dhsc/htbhf/page/PageName.java
+++ b/src/test/java/uk/gov/dhsc/htbhf/page/PageName.java
@@ -3,6 +3,8 @@ package uk.gov.dhsc.htbhf.page;
 import java.util.Arrays;
 import java.util.Optional;
 
+import static uk.gov.dhsc.htbhf.page.ToggleName.ADDRESS_LOOKUP;
+
 /**
  * Enum of all the page names
  */
@@ -16,8 +18,8 @@ public enum PageName {
     DO_YOU_HAVE_CHILDREN("do you have children under four years old"),
     EMAIL_ADDRESS("email address"),
     ENTER_CODE("enter code"),
-    POSTCODE("postcode", "ADDRESS_LOOKUP_ENABLED"),
-    SELECT_ADDRESS("select address", "ADDRESS_LOOKUP_ENABLED"),
+    POSTCODE("postcode", ADDRESS_LOOKUP),
+    SELECT_ADDRESS("select address", ADDRESS_LOOKUP),
     MANUAL_ADDRESS("manual address"),
     NAME("enter name"),
     NATIONAL_INSURANCE_NUMBER("enter national insurance number"),
@@ -35,14 +37,14 @@ public enum PageName {
     REPORT_A_CHANGE("Report a change");
 
     private String pageName;
-    private Optional<String> toggleName;
+    private Optional<ToggleName> toggleName;
 
     PageName(String pageName) {
         this.pageName = pageName;
         this.toggleName = Optional.empty();
     }
 
-    PageName(String pageName, String toggleName) {
+    PageName(String pageName, ToggleName toggleName) {
         this.pageName = pageName;
         this.toggleName = Optional.of(toggleName);
     }
@@ -62,7 +64,7 @@ public enum PageName {
         return toggleName.isPresent();
     }
 
-    public Optional<String> getToggle() {
+    public Optional<ToggleName> getToggle() {
         return toggleName;
     }
 }

--- a/src/test/java/uk/gov/dhsc/htbhf/page/PageNameTest.java
+++ b/src/test/java/uk/gov/dhsc/htbhf/page/PageNameTest.java
@@ -6,6 +6,7 @@ import org.junit.jupiter.params.provider.CsvSource;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.catchThrowableOfType;
+import static uk.gov.dhsc.htbhf.page.ToggleName.ADDRESS_LOOKUP;
 
 class PageNameTest {
 
@@ -54,6 +55,6 @@ class PageNameTest {
     @Test
     void shouldReturnNoToggle() {
         assertThat(PageName.HOW_IT_WORKS.getToggle()).isEmpty();
-        assertThat(PageName.POSTCODE.getToggle()).hasValue("ADDRESS_LOOKUP_ENABLED");
+        assertThat(PageName.POSTCODE.getToggle()).hasValue(ADDRESS_LOOKUP);
     }
 }

--- a/src/test/java/uk/gov/dhsc/htbhf/page/ToggleName.java
+++ b/src/test/java/uk/gov/dhsc/htbhf/page/ToggleName.java
@@ -1,0 +1,22 @@
+package uk.gov.dhsc.htbhf.page;
+
+import java.util.Arrays;
+
+/**
+ * An enum of all the toggle values. By default the toggle name is expected to be the name
+ * of this enum with _ENABLED as a suffix in the configuration.
+ */
+public enum ToggleName {
+    ADDRESS_LOOKUP;
+
+    public String getToggleName() {
+        return this.name() + "_ENABLED";
+    }
+
+    public static ToggleName toToggleName(String toggleString) {
+        return Arrays.stream(values())
+                .filter(toggleName -> toggleName.getToggleName().equals(toggleString))
+                .findFirst()
+                .orElseThrow(() -> new IllegalArgumentException("No toggle found for value: " + toggleString));
+    }
+}

--- a/src/test/java/uk/gov/dhsc/htbhf/page/ToggleName.java
+++ b/src/test/java/uk/gov/dhsc/htbhf/page/ToggleName.java
@@ -9,13 +9,13 @@ import java.util.Arrays;
 public enum ToggleName {
     ADDRESS_LOOKUP;
 
-    public String getToggleName() {
+    public String getFeatureKey() {
         return this.name() + "_ENABLED";
     }
 
     public static ToggleName toToggleName(String toggleString) {
         return Arrays.stream(values())
-                .filter(toggleName -> toggleName.getToggleName().equals(toggleString))
+                .filter(toggleName -> toggleName.getFeatureKey().equals(toggleString))
                 .findFirst()
                 .orElseThrow(() -> new IllegalArgumentException("No toggle found for value: " + toggleString));
     }

--- a/src/test/java/uk/gov/dhsc/htbhf/page/ToggleNameTest.java
+++ b/src/test/java/uk/gov/dhsc/htbhf/page/ToggleNameTest.java
@@ -1,0 +1,27 @@
+package uk.gov.dhsc.htbhf.page;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.catchThrowableOfType;
+
+class ToggleNameTest {
+
+    @Test
+    void shouldGetValidToggleName() {
+        assertThat(ToggleName.toToggleName("ADDRESS_LOOKUP_ENABLED")).isEqualTo(ToggleName.ADDRESS_LOOKUP);
+    }
+
+    @ValueSource(strings = {
+            "FOO_BAR_ENABLED",
+            "ADDRESS_LOOKUP",
+            ""
+    })
+    @ParameterizedTest
+    void shouldThrowExceptionForInvalidToggleName(String invalidToggle) {
+        IllegalArgumentException exception = catchThrowableOfType(() -> ToggleName.toToggleName(invalidToggle), IllegalArgumentException.class);
+        assertThat(exception).hasMessage("No toggle found for value: " + invalidToggle);
+    }
+}

--- a/src/test/java/uk/gov/dhsc/htbhf/page/ToggleNameTest.java
+++ b/src/test/java/uk/gov/dhsc/htbhf/page/ToggleNameTest.java
@@ -10,6 +10,11 @@ import static org.assertj.core.api.Assertions.catchThrowableOfType;
 class ToggleNameTest {
 
     @Test
+    void shouldGetFullFeatureKeyFromEnum() {
+        assertThat(ToggleName.ADDRESS_LOOKUP.getFeatureKey()).isEqualTo("ADDRESS_LOOKUP_ENABLED");
+    }
+
+    @Test
     void shouldGetValidToggleName() {
         assertThat(ToggleName.toToggleName("ADDRESS_LOOKUP_ENABLED")).isEqualTo(ToggleName.ADDRESS_LOOKUP);
     }

--- a/src/test/java/uk/gov/dhsc/htbhf/steps/ClaimValuesTestDataFactory.java
+++ b/src/test/java/uk/gov/dhsc/htbhf/steps/ClaimValuesTestDataFactory.java
@@ -47,6 +47,6 @@ public class ClaimValuesTestDataFactory {
                 .county(COUNTY)
                 .postcode(POSTCODE)
                 .nino(generateEligibleNino())
-                .selectAddress(false);
+                .selectAddress(true);
     }
 }

--- a/src/test/java/uk/gov/dhsc/htbhf/utils/ToggleConfiguration.java
+++ b/src/test/java/uk/gov/dhsc/htbhf/utils/ToggleConfiguration.java
@@ -5,6 +5,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang3.StringUtils;
 import uk.gov.dhsc.htbhf.page.PageName;
+import uk.gov.dhsc.htbhf.page.ToggleName;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -45,12 +46,12 @@ public class ToggleConfiguration {
         return toggles;
     }
 
-    public boolean isEnabled(String toggle) {
-        return toggles.getOrDefault(toggle, false);
+    public boolean isEnabled(ToggleName toggle) {
+        return toggles.getOrDefault(toggle.getToggleName(), false);
     }
 
     public boolean isPageEnabled(PageName pageName) {
-        Optional<String> toggle = pageName.getToggle();
+        Optional<ToggleName> toggle = pageName.getToggle();
         return toggle.map(this::isEnabled).orElse(true);
     }
 }

--- a/src/test/java/uk/gov/dhsc/htbhf/utils/ToggleConfiguration.java
+++ b/src/test/java/uk/gov/dhsc/htbhf/utils/ToggleConfiguration.java
@@ -47,7 +47,7 @@ public class ToggleConfiguration {
     }
 
     public boolean isEnabled(ToggleName toggle) {
-        return toggles.getOrDefault(toggle.getToggleName(), false);
+        return toggles.getOrDefault(toggle.getFeatureKey(), false);
     }
 
     public boolean isPageEnabled(PageName pageName) {

--- a/src/test/java/uk/gov/dhsc/htbhf/utils/ToggleConfigurationTest.java
+++ b/src/test/java/uk/gov/dhsc/htbhf/utils/ToggleConfigurationTest.java
@@ -2,6 +2,7 @@ package uk.gov.dhsc.htbhf.utils;
 
 import org.junit.jupiter.api.Test;
 import uk.gov.dhsc.htbhf.page.PageName;
+import uk.gov.dhsc.htbhf.page.ToggleName;
 
 import java.util.Map;
 
@@ -22,22 +23,10 @@ class ToggleConfigurationTest {
         ToggleConfiguration toggleConfiguration = new ToggleConfiguration(VALID_TOGGLE_CONFIG);
         //When
         Map<String, Boolean> allToggles = toggleConfiguration.getAllToggles();
-        boolean addressToggled = toggleConfiguration.isEnabled("ADDRESS_LOOKUP_ENABLED");
-        boolean fooBarToggled = toggleConfiguration.isEnabled("FOOBAR_ENABLED");
+        boolean addressToggled = toggleConfiguration.isEnabled(ToggleName.ADDRESS_LOOKUP);
         //Then
         assertThat(allToggles).hasSize(2);
         assertThat(addressToggled).isFalse();
-        assertThat(fooBarToggled).isTrue();
-    }
-
-    @Test
-    void shouldNotBeEnabledForMissingToggle() {
-        //Given
-        ToggleConfiguration toggleConfiguration = new ToggleConfiguration(VALID_TOGGLE_CONFIG);
-        //When
-        boolean somethingEnabled = toggleConfiguration.isEnabled("SOMETHING_ENABLED");
-        //Then
-        assertThat(somethingEnabled).isFalse();
     }
 
     @Test


### PR DESCRIPTION
 - Set a default value of blank string for toggle environment variable value to stop stack trace hitting console in this scenario (its still defaults to no toggles correctly).
 - Modify the creation of page steps so they are built each time and can evaluate the steps required based on the values in the ClaimValues object.
 - Add enum for ToggleNames so that we have type safely when we are using this interactively in the code building up steps for a test.
 - Set the default for end-to-end tests to test via the postcode lookup, which makes sure that the compatibility tests test the postcode lookup rather than defaulting to the manual address page.