### PR TITLE
Add address lookup scenarios and associated steps.

### DIFF
--- a/src/test/java/uk/gov/dhsc/htbhf/local/LocalWebDriverWrapper.java
+++ b/src/test/java/uk/gov/dhsc/htbhf/local/LocalWebDriverWrapper.java
@@ -68,7 +68,7 @@ public class LocalWebDriverWrapper implements WebDriverWrapper {
             case "chrome":
                 ChromeOptions chromeOptions = new ChromeOptions();
                 chromeOptions.setHeadless(headless);
-                chromeOptions.addArguments("--headless", "--whitelisted-ips", "--no-sandbox", "--disable-extensions");
+                chromeOptions.addArguments("--whitelisted-ips", "--no-sandbox", "--disable-extensions");
                 webdriver = new ChromeDriver(chromeOptions);
                 break;
         }

--- a/src/test/java/uk/gov/dhsc/htbhf/local/LocalWebDriverWrapper.java
+++ b/src/test/java/uk/gov/dhsc/htbhf/local/LocalWebDriverWrapper.java
@@ -68,6 +68,7 @@ public class LocalWebDriverWrapper implements WebDriverWrapper {
             case "chrome":
                 ChromeOptions chromeOptions = new ChromeOptions();
                 chromeOptions.setHeadless(headless);
+                chromeOptions.addArguments("--headless", "--whitelisted-ips", "--no-sandbox", "--disable-extensions");
                 webdriver = new ChromeDriver(chromeOptions);
                 break;
         }

--- a/src/test/java/uk/gov/dhsc/htbhf/page/PostcodePage.java
+++ b/src/test/java/uk/gov/dhsc/htbhf/page/PostcodePage.java
@@ -32,4 +32,12 @@ public class PostcodePage extends SubmittablePage {
     public void enterPostcode(String postcode) {
         postcodeInputField.enterValue(postcode);
     }
+
+    public String getPostcodeInputErrorId() {
+        return postcodeInputField.getInputErrorId();
+    }
+
+    public String getPostcodeInputErrorLinkCss() {
+        return postcodeInputField.getInputErrorLinkCss();
+    }
 }

--- a/src/test/java/uk/gov/dhsc/htbhf/steps/AddressLookupSteps.java
+++ b/src/test/java/uk/gov/dhsc/htbhf/steps/AddressLookupSteps.java
@@ -1,0 +1,132 @@
+package uk.gov.dhsc.htbhf.steps;
+
+import io.cucumber.java.en.Given;
+import io.cucumber.java.en.Then;
+import io.cucumber.java.en.When;
+import org.openqa.selenium.WebElement;
+import uk.gov.dhsc.htbhf.page.PostcodePage;
+import uk.gov.dhsc.htbhf.page.SelectAddressPage;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static uk.gov.dhsc.htbhf.steps.Constants.POSTCODE;
+import static uk.gov.dhsc.htbhf.steps.Constants.POSTCODE_WITH_NO_RESULTS;
+import static uk.gov.dhsc.htbhf.utils.WiremockResponseTestDataFactory.aPostcodeLookupResponseWithResults;
+
+/**
+ * Steps for looking up addresses for a claimant
+ */
+public class AddressLookupSteps extends CommonSteps {
+
+    @Given("OS places returns an error response")
+    public void givenOsPlacesReturnsAnError() {
+        setupPostcodeLookupWithResults(POSTCODE_WITH_NO_RESULTS);
+        enterPostcodeAndSubmit(POSTCODE_WITH_NO_RESULTS);
+    }
+
+    @When("^I enter a postcode that returns no search results")
+    public void enterPostcodeWithNoSearchResults() {
+        setupPostcodeLookupWithResults(POSTCODE_WITH_NO_RESULTS);
+        enterPostcodeAndSubmit(POSTCODE_WITH_NO_RESULTS);
+    }
+
+    @When("^I enter a postcode that returns search results")
+    public void enterPostcodeWithSearchResults() {
+        setupPostcodeLookupWithResults(POSTCODE);
+        enterPostcodeAndSubmit(POSTCODE);
+    }
+
+    @When("^I enter (.*) as my postcode")
+    public void enterPostcode(String postcode) {
+        enterPostcodeAndSubmit(postcode);
+    }
+
+    @When("^I select an address")
+    public void selectAnAddress() {
+        getPages().getSelectAddressPage().selectFirstAddress();
+    }
+
+    @When("^I click the address not listed link")
+    public void selectAddressNotListedLink() {
+        getPages().getSelectAddressPage().clickAddressNotListedLink();
+    }
+
+    @When("^I click the change postcode link")
+    public void selectChangePostcodeLink() {
+        getPages().getSelectAddressPage().clickChangePostcodeLink();
+    }
+
+    @Then("^I am shown a list of addresses")
+    public void listOfAddressesAreShown() {
+        List<WebElement> addressOptions = getPages().getSelectAddressPage().getAddressOptions();
+        assertThat(addressOptions).hasSize(2);
+        verifyAddressOptionsText(POSTCODE, addressOptions);
+    }
+
+    @Then("^I am informed that no addresses were found for my postcode")
+    public void noAddressesFoundForPostcode() {
+        WebElement addressNotFoundElement = getPages().getSelectAddressPage().getAddressNotFoundElement();
+        assertThat(addressNotFoundElement.isDisplayed()).isTrue();
+    }
+
+    @Then("^I am shown a link to change my postcode")
+    public void changePostcodeLinkIsShown() {
+        SelectAddressPage selectAddressPage = getPages().getSelectAddressPage();
+        WebElement changePostcodeLink = selectAddressPage.getChangePostcodeLink();
+        String href = changePostcodeLink.getAttribute("href");
+        assertThat(href).isEqualTo(getPages().getPostcodePage().getFullPath());
+    }
+
+    @Then("^I am shown a button to enter my address manually")
+    public void enterManualAddressButtonIsShown() {
+        String buttonText = getPages().getSelectAddressPage().getSubmitButtonText();
+        assertThat(buttonText).isEqualTo("Enter address manually");
+    }
+
+    @Then("^I am shown an address not listed link")
+    public void addressNotListedLinkShown() {
+        WebElement addressNotListedLink = getPages().getSelectAddressPage().getAddressNotListedLink();
+        String href = addressNotListedLink.getAttribute("href");
+        assertThat(href).isEqualTo(getPages().getManualAddressPage().getFullPath());
+    }
+
+    @Then("^I am shown a continue button")
+    public void continueButtonIsShown() {
+        String buttonText = getPages().getSelectAddressPage().getSubmitButtonText();
+        assertThat(buttonText).isEqualTo("Continue");
+    }
+
+    @Then("^I am informed that the postcode is in the wrong format")
+    public void assertPostcodeInWrongFormat() {
+        assertPostcodeErrorPresent("Enter a correct postcode, like AA1 1AA");
+    }
+
+    @Then("^I am informed that you can only apply if I live in England, Wales or Northern Ireland")
+    public void assertPostcodeNotInEnglandWalesOrNorthernIreland() {
+        assertPostcodeErrorPresent("You can only apply if you live in England, Wales or Northern Ireland");
+    }
+
+    private void assertPostcodeErrorPresent(String expectedErrorMessage) {
+        PostcodePage postcodePage = getPages().getPostcodePage();
+        assertErrorHeaderTextPresent(postcodePage);
+        assertFieldErrorAndLinkTextPresentAndCorrect(postcodePage,
+                postcodePage.getPostcodeInputErrorId(),
+                postcodePage.getPostcodeInputErrorLinkCss(),
+                expectedErrorMessage);
+    }
+
+    private void verifyAddressOptionsText(String postcode, List<WebElement> options) {
+        String mockApiResponse = aPostcodeLookupResponseWithResults(postcode);
+        List<String> addressLines = mockApiResponse.lines().filter(line -> line.trim().startsWith("\"ADDRESS\"")).collect(Collectors.toList());
+        options.forEach(option -> assertAddressOptionTextMatchesResult(addressLines, option));
+    }
+
+    private void assertAddressOptionTextMatchesResult(List<String> addressLines, WebElement option) {
+        String optionText = option.getText().toUpperCase();
+        boolean matchFound = addressLines.stream().anyMatch(addressLine -> addressLine.contains(optionText));
+        assertThat(matchFound).as("Expecting to find address option in Wiremock mapping: " + optionText).isTrue();
+    }
+
+}

--- a/src/test/java/uk/gov/dhsc/htbhf/steps/CheckAnswersSteps.java
+++ b/src/test/java/uk/gov/dhsc/htbhf/steps/CheckAnswersSteps.java
@@ -37,6 +37,11 @@ public class CheckAnswersSteps extends CommonSteps {
         changeAnswerFor("Are you pregnant?");
     }
 
+    @When("^I choose to change my address")
+    public void changeAddress() {
+        changeAnswerFor("Address");
+    }
+
     @Then("^there are no children displayed")
     public void thereAreNoChildrenDisplayed() {
         CheckAnswersPage checkAnswersPage = getPages().getCheckAnswersPage();

--- a/src/test/java/uk/gov/dhsc/htbhf/steps/Constants.java
+++ b/src/test/java/uk/gov/dhsc/htbhf/steps/Constants.java
@@ -14,6 +14,7 @@ public class Constants {
     public static final String TOWN = "Springfield";
     public static final String COUNTY = "Devon";
     public static final String POSTCODE = "AA11BB";
+    public static final String POSTCODE_WITH_NO_RESULTS = "BS11AA";
     public static final String FULL_ADDRESS = ADDRESS_LINE_1 + "\n" + ADDRESS_LINE_2 + "\n" + TOWN + "\n" + COUNTY + "\n" + POSTCODE;
     public static final String FULL_ADDRESS_NO_LINE_2 = ADDRESS_LINE_1 + "\n" + TOWN + "\n" + COUNTY + "\n" + POSTCODE;
     public static final String FULL_ADDRESS_NO_COUNTY = ADDRESS_LINE_1 + "\n" + ADDRESS_LINE_2 + "\n" + TOWN + "\n" + POSTCODE;

--- a/src/test/java/uk/gov/dhsc/htbhf/utils/WireMockManagerImpl.java
+++ b/src/test/java/uk/gov/dhsc/htbhf/utils/WireMockManagerImpl.java
@@ -1,10 +1,12 @@
 package uk.gov.dhsc.htbhf.utils;
 
 import com.github.tomakehurst.wiremock.WireMockServer;
+import uk.gov.dhsc.htbhf.steps.Constants;
 
 import java.util.Map;
 
 import static com.github.tomakehurst.wiremock.client.WireMock.*;
+import static uk.gov.dhsc.htbhf.utils.WiremockResponseTestDataFactory.aPostcodeLookupResponseWithNoResults;
 import static uk.gov.dhsc.htbhf.utils.WiremockResponseTestDataFactory.aPostcodeLookupResponseWithResults;
 import static uk.gov.dhsc.htbhf.utils.WiremockResponseTestDataFactory.aValidClaimResponseWithVoucherEntitlement;
 import static uk.gov.dhsc.htbhf.utils.WiremockResponseTestDataFactory.aValidClaimResponseWithoutVoucherEntitlement;
@@ -71,7 +73,9 @@ public class WireMockManagerImpl implements WireMockManager {
 
     @Override
     public void setupPostcodeLookupWithResultsMapping(String postcode) {
-        String wireMockBody = aPostcodeLookupResponseWithResults(postcode);
+        String wireMockBody =  (postcode.equalsIgnoreCase(Constants.POSTCODE_WITH_NO_RESULTS))
+                ? aPostcodeLookupResponseWithNoResults()
+                : aPostcodeLookupResponseWithResults(postcode);
         osPlacesMock.stubFor(get(urlPathEqualTo(POSTCODE_LOOKUP_ENDPOINT))
                 .withQueryParam("postcode", equalTo(postcode))
                 .withQueryParam("key", matching(".*"))

--- a/src/test/java/uk/gov/dhsc/htbhf/utils/WiremockResponseTestDataFactory.java
+++ b/src/test/java/uk/gov/dhsc/htbhf/utils/WiremockResponseTestDataFactory.java
@@ -39,6 +39,10 @@ public class WiremockResponseTestDataFactory {
                 "}";
     }
 
+    public static String aPostcodeLookupResponseWithNoResults() {
+        return getResponseTemplate("postcode-lookup-no-results.json");
+    }
+
     public static String aPostcodeLookupResponseWithResults(String postcode) {
         String template = getResponseTemplate("postcode-lookup-2-results.json");
         return template.replace(DEFAULT_POSTCODE, postcode);

--- a/src/test/resources/features/acceptance/address-lookup.feature
+++ b/src/test/resources/features/acceptance/address-lookup.feature
@@ -1,0 +1,87 @@
+Feature: Select address
+  In order to apply for the Apply for Healthy Start programme
+  As a potential claimant
+  I want to lookup my address
+
+  Scenario: Entering a postcode with no search results shows that no addresses were found
+    Given I have entered my details up to the postcode page
+    When I enter a postcode that returns no search results
+    Then I am shown the select address page
+    And I am informed that no addresses were found for my postcode
+    And I am shown a link to change my postcode
+    And I am shown a button to enter my address manually
+
+  Scenario: Entering a postcode shows a list of matching addresses
+    Given I have entered my details up to the postcode page
+    When I enter a postcode that returns search results
+    Then I am shown the select address page
+    And I am shown a list of addresses
+    And I am shown an address not listed link
+    And I am shown a continue button
+
+  Scenario: Selecting an address skips the manual address page
+    Given I have entered my details up to the select address page
+    When I select an address
+    And I click continue
+    Then I am shown the phone number page
+
+  Scenario: Clicking the address not listed link shows the manual address page
+    Given I have entered my details up to the select address page
+    When I click the address not listed link
+    Then I am shown the manual address page
+
+  Scenario: Changing details for a selected address takes me to the select address page
+    Given I have entered my details up to the check answers page
+    When I choose to change my address
+    Then I am shown the select address page
+
+  Scenario: Entering a new postcode when I have selected to change my address takes me to the select address page
+    Given I have entered my details up to the check answers page
+    When I choose to change my address
+    And I click the change postcode link
+    And I enter a postcode that returns search results
+    Then I am shown the select address page
+
+  Scenario: Clicking the address not listed link when I have selected to change my answer for select address takes me to the manual address page
+    Given I have entered my details up to the check answers page
+    When I choose to change my address
+    And I click the address not listed link
+    Then I am shown the manual address page
+
+  Scenario Outline: Enter an invalid postcode on the postcode lookup page
+    Given I have entered my details up to the postcode page
+    When I enter <postcode> as my postcode
+    Then I am informed that the postcode is in the wrong format
+
+    Examples:
+      | postcode |
+      | AA1122BB |
+      | A        |
+      | 11AA21   |
+
+  Scenario Outline: Entering a postcode from the Channel Islands or Isle of Man shows an error
+    Given I have entered my details up to the postcode page
+    When I enter <postcode> as my postcode
+    Then I am informed that you can only apply if I live in England, Wales or Northern Ireland
+
+    Examples:
+      | postcode |
+      | GY1 1WR  |
+      | JE3 1FU  |
+      | IM1 3LY  |
+
+#  Scenario: I am shown an error response when a bad response is returned from os places and I can then enter my address manually
+#    Given I have entered my details up to the postcode page
+#    And OS places returns an error response
+#    When I enter my postcode
+#    Then I am shown the select address page
+#    And I am informed that there's a problem with the address lookup
+#    And I am shown a link to enter my address manually
+#
+#  Scenario: I am shown an error response when there are connection issues with os places and I can then enter my address manually
+#    Given I have entered my details up to the postcode page
+#    And OS places resets the connection
+#    When I enter my postcode
+#    Then I am shown the select address page
+#    And I am informed that there's a problem with the address lookup
+#    And I am shown a link to enter my address manually

--- a/src/test/resources/features/acceptance/address-lookup.feature
+++ b/src/test/resources/features/acceptance/address-lookup.feature
@@ -1,3 +1,4 @@
+@ADDRESS_LOOKUP
 Feature: Select address
   In order to apply for the Apply for Healthy Start programme
   As a potential claimant

--- a/src/test/resources/wiremock/mappings/postcode-lookup-2-results.json
+++ b/src/test/resources/wiremock/mappings/postcode-lookup-2-results.json
@@ -3,7 +3,7 @@
     "uri" : "https://api.ordnancesurvey.co.uk/places/v1/addresses/postcode?postcode=AA11BB",
     "query" : "postcode=AA11BB",
     "offset" : 0,
-    "totalresults" : 44,
+    "totalresults" : 2,
     "format" : "JSON",
     "dataset" : "DPA",
     "lr" : "EN,CY",

--- a/src/test/resources/wiremock/mappings/postcode-lookup-no-results.json
+++ b/src/test/resources/wiremock/mappings/postcode-lookup-no-results.json
@@ -1,0 +1,14 @@
+{
+  "header": {
+    "uri": "https://api.ordnancesurvey.co.uk/places/v1/addresses/postcode?postcode=bs11aa",
+    "query": "postcode=bs11aa",
+    "offset": 0,
+    "totalresults": 0,
+    "format": "JSON",
+    "dataset": "DPA",
+    "lr": "EN,CY",
+    "maxresults": 100,
+    "epoch": "69",
+    "output_srs": "EPSG:27700"
+  }
+}


### PR DESCRIPTION
Have done all the positive and failure scenarios for this file, just got the OS places error tests to do, but wanted to stop at this point as I need to do a bit of a refactor on the WireMock classes and files to do this so wanted it in another PR.

It should be noted that the response that comes back from WireMock for these tests is different from that used in web-ui, it returns 2 results rather than 11. I might change it to the same as the web-ui in its own PR later if time permits.