### PR TITLE
HTBHF-2248 Add scenarios for error responses coming back from OS places API calls.

### DIFF
--- a/run_tests_with_local_feature_toggles.sh
+++ b/run_tests_with_local_feature_toggles.sh
@@ -14,4 +14,4 @@ export TAGS=$(cat ${WEB_UI_DIR}/features.json | grep false | sed 's/": false//g'
 
 echo "Using feature toggles: ${FEATURE_TOGGLES}"
 echo "Runing tests with: -Dcucumber.options=\"--tags 'not @Ignore ${TAGS}'\""
-./gradlew -Dcucumber.options="--tags 'not @Ignore ${TAGS}'" clean build --info -s
+./gradlew -Dcucumber.options="--tags 'not @Ignore ${TAGS}'" clean build --info --stacktrace

--- a/src/test/java/uk/gov/dhsc/htbhf/page/SelectAddressPage.java
+++ b/src/test/java/uk/gov/dhsc/htbhf/page/SelectAddressPage.java
@@ -43,12 +43,21 @@ public class SelectAddressPage extends SubmittablePage {
         return findAllByCss(ADDRESS_RESULTS_OPTION_CSS);
     }
 
-    public WebElement getAddressNotListedLink () {
+    private WebElement getAddressNotListedLink() {
         return findByXpath("//a[contains(text(), \"My address is not listed\")]");
     }
 
-    public WebElement getChangePostcodeLink () {
+    public String getAddressNotListedLinkHref() {
+        WebElement addressNotListedLink = getAddressNotListedLink();
+        return addressNotListedLink.getAttribute("href");
+    }
+
+    private WebElement getChangePostcodeLink() {
         return findByXpath("//a[contains(text(), \"Change\")]");
+    }
+
+    public String getChangePostcodeLinkHref() {
+        return getChangePostcodeLink().getAttribute("href");
     }
 
     public void clickAddressNotListedLink () {
@@ -61,8 +70,9 @@ public class SelectAddressPage extends SubmittablePage {
         changePostcodeLink.click();
     }
 
-    public WebElement getManualAddressLink () {
-        return findByXpath("//a[contains(text(), \"Enter address manually\")]");
+    public String getManualAddressLinkHref() {
+        WebElement manualAddressLink = findByXpath("//a[contains(text(), \"Enter address manually\")]");
+        return manualAddressLink.getAttribute("href");
     }
 
     public void selectFirstAddress() {

--- a/src/test/java/uk/gov/dhsc/htbhf/steps/AddressLookupSteps.java
+++ b/src/test/java/uk/gov/dhsc/htbhf/steps/AddressLookupSteps.java
@@ -5,7 +5,6 @@ import io.cucumber.java.en.Then;
 import io.cucumber.java.en.When;
 import org.openqa.selenium.WebElement;
 import uk.gov.dhsc.htbhf.page.PostcodePage;
-import uk.gov.dhsc.htbhf.page.SelectAddressPage;
 
 import java.util.List;
 import java.util.stream.Collectors;
@@ -22,8 +21,12 @@ public class AddressLookupSteps extends CommonSteps {
 
     @Given("OS places returns an error response")
     public void givenOsPlacesReturnsAnError() {
-        setupPostcodeLookupWithResults(POSTCODE_WITH_NO_RESULTS);
-        enterPostcodeAndSubmit(POSTCODE_WITH_NO_RESULTS);
+        wireMockManager.setupPostcodeLookupErrorResponse();
+    }
+
+    @Given("OS places resets the connection")
+    public void givenOsResetsTheConnection() {
+        wireMockManager.setupPostcodeLookupConnectionResetResponse();
     }
 
     @When("^I enter a postcode that returns no search results")
@@ -41,6 +44,11 @@ public class AddressLookupSteps extends CommonSteps {
     @When("^I enter (.*) as my postcode")
     public void enterPostcode(String postcode) {
         enterPostcodeAndSubmit(postcode);
+    }
+
+    @When("^I enter my postcode")
+    public void enterPostcode() {
+        enterPostcodeAndSubmit(POSTCODE);
     }
 
     @When("^I select an address")
@@ -73,10 +81,8 @@ public class AddressLookupSteps extends CommonSteps {
 
     @Then("^I am shown a link to change my postcode")
     public void changePostcodeLinkIsShown() {
-        SelectAddressPage selectAddressPage = getPages().getSelectAddressPage();
-        WebElement changePostcodeLink = selectAddressPage.getChangePostcodeLink();
-        String href = changePostcodeLink.getAttribute("href");
-        assertThat(href).isEqualTo(getPages().getPostcodePage().getFullPath());
+        String changePostcodeLinkHref = getPages().getSelectAddressPage().getChangePostcodeLinkHref();
+        assertThat(changePostcodeLinkHref).isEqualTo(getPages().getPostcodePage().getFullPath());
     }
 
     @Then("^I am shown a button to enter my address manually")
@@ -87,9 +93,8 @@ public class AddressLookupSteps extends CommonSteps {
 
     @Then("^I am shown an address not listed link")
     public void addressNotListedLinkShown() {
-        WebElement addressNotListedLink = getPages().getSelectAddressPage().getAddressNotListedLink();
-        String href = addressNotListedLink.getAttribute("href");
-        assertThat(href).isEqualTo(getPages().getManualAddressPage().getFullPath());
+        String addressNotListedLinkHref = getPages().getSelectAddressPage().getAddressNotListedLinkHref();
+        assertThat(addressNotListedLinkHref).isEqualTo(getPages().getManualAddressPage().getFullPath());
     }
 
     @Then("^I am shown a continue button")
@@ -106,6 +111,18 @@ public class AddressLookupSteps extends CommonSteps {
     @Then("^I am informed that you can only apply if I live in England, Wales or Northern Ireland")
     public void assertPostcodeNotInEnglandWalesOrNorthernIreland() {
         assertPostcodeErrorPresent("You can only apply if you live in England, Wales or Northern Ireland");
+    }
+
+    @Then("^I am informed that there's a problem with the address lookup")
+    public void postcodeLookupNotWorkingErrorShown() {
+        WebElement postcodeLookupNotWorkingElement = getPages().getSelectAddressPage().getPostcodeLookupNotWorkingElement();
+        assertThat(postcodeLookupNotWorkingElement.isDisplayed()).isTrue();
+    }
+
+    @Then("^I am shown a link to enter my address manually")
+    public void manualAddressLinkIsShown() {
+        String manualAddressLink = getPages().getSelectAddressPage().getManualAddressLinkHref();
+        assertThat(manualAddressLink).isEqualTo(getPages().getManualAddressPage().getFullPath());
     }
 
     private void assertPostcodeErrorPresent(String expectedErrorMessage) {

--- a/src/test/java/uk/gov/dhsc/htbhf/steps/CommonSteps.java
+++ b/src/test/java/uk/gov/dhsc/htbhf/steps/CommonSteps.java
@@ -1,11 +1,9 @@
 package uk.gov.dhsc.htbhf.steps;
 
 import lombok.extern.slf4j.Slf4j;
-import org.openqa.selenium.WebElement;
 import uk.gov.dhsc.htbhf.page.*;
 
 import java.util.LinkedHashMap;
-import java.util.List;
 import java.util.Map;
 import java.util.function.Consumer;
 
@@ -79,7 +77,7 @@ public class CommonSteps extends BaseSteps {
         if (toggleConfiguration.isPageEnabled(pageName)) {
             pageActions.put(pageName, pageAction);
         } else {
-            log.info("Not adding page action for [{}] as it is toggled off", pageName);
+            log.debug("Not adding page action for [{}] as it is toggled off", pageName);
         }
     }
 

--- a/src/test/java/uk/gov/dhsc/htbhf/utils/WireMockManager.java
+++ b/src/test/java/uk/gov/dhsc/htbhf/utils/WireMockManager.java
@@ -19,4 +19,10 @@ public interface WireMockManager {
 
     default void setupPostcodeLookupWithResultsMapping(String postcode){
     }
+
+    default void setupPostcodeLookupErrorResponse() {
+    }
+
+    default void setupPostcodeLookupConnectionResetResponse() {
+    }
 }

--- a/src/test/java/uk/gov/dhsc/htbhf/utils/WireMockManagerImpl.java
+++ b/src/test/java/uk/gov/dhsc/htbhf/utils/WireMockManagerImpl.java
@@ -1,15 +1,13 @@
 package uk.gov.dhsc.htbhf.utils;
 
 import com.github.tomakehurst.wiremock.WireMockServer;
+import com.github.tomakehurst.wiremock.http.Fault;
 import uk.gov.dhsc.htbhf.steps.Constants;
 
 import java.util.Map;
 
 import static com.github.tomakehurst.wiremock.client.WireMock.*;
-import static uk.gov.dhsc.htbhf.utils.WiremockResponseTestDataFactory.aPostcodeLookupResponseWithNoResults;
-import static uk.gov.dhsc.htbhf.utils.WiremockResponseTestDataFactory.aPostcodeLookupResponseWithResults;
-import static uk.gov.dhsc.htbhf.utils.WiremockResponseTestDataFactory.aValidClaimResponseWithVoucherEntitlement;
-import static uk.gov.dhsc.htbhf.utils.WiremockResponseTestDataFactory.aValidClaimResponseWithoutVoucherEntitlement;
+import static uk.gov.dhsc.htbhf.utils.WiremockResponseTestDataFactory.*;
 
 /**
  * Manages all interactions with WireMock
@@ -83,5 +81,22 @@ public class WireMockManagerImpl implements WireMockManager {
                         .withStatus(200)
                         .withHeader("Content-Type", "application/json")
                         .withBody(wireMockBody)));
+    }
+
+    @Override
+    public void setupPostcodeLookupErrorResponse() {
+        osPlacesMock.stubFor(get(urlPathEqualTo(POSTCODE_LOOKUP_ENDPOINT))
+                .withQueryParam("key", matching(".*"))
+                .willReturn(aResponse()
+                        .withStatus(500)
+                        .withHeader("Content-Type", "application/json")
+                        .withBody(aPostcodeLookup500ErrorResponse())));
+    }
+
+    @Override
+    public void setupPostcodeLookupConnectionResetResponse() {
+        osPlacesMock.stubFor(get(urlPathEqualTo(POSTCODE_LOOKUP_ENDPOINT))
+                .withQueryParam("key", matching(".*"))
+                .willReturn(aResponse().withFault(Fault.CONNECTION_RESET_BY_PEER)));
     }
 }

--- a/src/test/java/uk/gov/dhsc/htbhf/utils/WiremockResponseTestDataFactory.java
+++ b/src/test/java/uk/gov/dhsc/htbhf/utils/WiremockResponseTestDataFactory.java
@@ -39,6 +39,10 @@ public class WiremockResponseTestDataFactory {
                 "}";
     }
 
+    public static String aPostcodeLookup500ErrorResponse() {
+        return getResponseTemplate("postcode-lookup-error-500-response.json");
+    }
+
     public static String aPostcodeLookupResponseWithNoResults() {
         return getResponseTemplate("postcode-lookup-no-results.json");
     }

--- a/src/test/resources/features/acceptance/address-lookup.feature
+++ b/src/test/resources/features/acceptance/address-lookup.feature
@@ -71,18 +71,18 @@ Feature: Select address
       | JE3 1FU  |
       | IM1 3LY  |
 
-#  Scenario: I am shown an error response when a bad response is returned from os places and I can then enter my address manually
-#    Given I have entered my details up to the postcode page
-#    And OS places returns an error response
-#    When I enter my postcode
-#    Then I am shown the select address page
-#    And I am informed that there's a problem with the address lookup
-#    And I am shown a link to enter my address manually
-#
-#  Scenario: I am shown an error response when there are connection issues with os places and I can then enter my address manually
-#    Given I have entered my details up to the postcode page
-#    And OS places resets the connection
-#    When I enter my postcode
-#    Then I am shown the select address page
-#    And I am informed that there's a problem with the address lookup
-#    And I am shown a link to enter my address manually
+  Scenario: I am shown an error response when a bad response is returned from os places and I can then enter my address manually
+    Given I have entered my details up to the postcode page
+    And OS places returns an error response
+    When I enter my postcode
+    Then I am shown the select address page
+    And I am informed that there's a problem with the address lookup
+    And I am shown a link to enter my address manually
+
+  Scenario: I am shown an error response when there are connection issues with os places and I can then enter my address manually
+    Given I have entered my details up to the postcode page
+    And OS places resets the connection
+    When I enter my postcode
+    Then I am shown the select address page
+    And I am informed that there's a problem with the address lookup
+    And I am shown a link to enter my address manually

--- a/src/test/resources/wiremock/mappings/postcode-lookup-error-500-response.json
+++ b/src/test/resources/wiremock/mappings/postcode-lookup-error-500-response.json
@@ -1,0 +1,12 @@
+{
+  "header": {
+    "offset": 0,
+    "totalresults": 0,
+    "format": "JSON",
+    "dataset": "DPA",
+    "lr": "EN,CY",
+    "maxresults": 100,
+    "epoch": "69",
+    "output_srs": "EPSG:27700"
+  }
+}


### PR DESCRIPTION
- The final two scenarios have now been enabled and implemented.
- Change the steps log message to DEBUG level.
- Tidied up a few of the SelectAddressPage methods so that they hide access to the WebElements and simply return the data that the Steps need.