### PR TITLE
Create and use a generic step for verifying the back link is correct.

### DIFF
--- a/src/test/java/uk/gov/dhsc/htbhf/steps/CheckAnswersSteps.java
+++ b/src/test/java/uk/gov/dhsc/htbhf/steps/CheckAnswersSteps.java
@@ -5,7 +5,6 @@ import io.cucumber.java.en.When;
 import org.openqa.selenium.WebElement;
 import uk.gov.dhsc.htbhf.page.CheckAnswersPage;
 import uk.gov.dhsc.htbhf.page.CheckAnswersRowData;
-import uk.gov.dhsc.htbhf.page.PageName;
 
 import java.util.List;
 import java.util.Map;
@@ -108,11 +107,6 @@ public class CheckAnswersSteps extends CommonSteps {
     @Then("^the check answers page contains all data entered for an applicant with no county")
     public void checkAnswerPageContainsAllDataForApplicantWithNoCounty() {
         assertCheckAnswersWithAddressForClaimantWithChildrenAndNotPregnant(FULL_ADDRESS_NO_COUNTY);
-    }
-
-    @Then("^The back link on the check answers page links to the email address page")
-    public void backLinkPointsToEmailAddressPage() {
-        assertBackLinkPointsToPage(PageName.EMAIL_ADDRESS);
     }
 
     private void changeAnswerFor(String linkText) {

--- a/src/test/java/uk/gov/dhsc/htbhf/steps/ChildDateOfBirthSteps.java
+++ b/src/test/java/uk/gov/dhsc/htbhf/steps/ChildDateOfBirthSteps.java
@@ -5,7 +5,6 @@ import io.cucumber.java.en.Then;
 import io.cucumber.java.en.When;
 import org.openqa.selenium.WebElement;
 import uk.gov.dhsc.htbhf.page.ChildDateOfBirthPage;
-import uk.gov.dhsc.htbhf.page.PageName;
 
 import java.time.LocalDate;
 import java.util.List;
@@ -112,11 +111,6 @@ public class ChildDateOfBirthSteps extends CommonSteps {
         childDateOfBirthPage.clickAddAnotherChild();
         childDateOfBirthPage.enterChild3OrUnderDetails(LONG_STRING, 1);
         childDateOfBirthPage.clickContinue();
-    }
-
-    @Then("^The back link points to the Enter your children’s dates of birth page")
-    public void assertBackLinkPointsToChildsDateOfBirthPage() {
-        assertBackLinkPointsToPage(PageName.CHILD_DATE_OF_BIRTH);
     }
 
     @Then("^there are no Remove Child buttons visible")

--- a/src/test/java/uk/gov/dhsc/htbhf/steps/DoYouHaveChildrenSteps.java
+++ b/src/test/java/uk/gov/dhsc/htbhf/steps/DoYouHaveChildrenSteps.java
@@ -3,7 +3,6 @@ package uk.gov.dhsc.htbhf.steps;
 import io.cucumber.java.en.Then;
 import io.cucumber.java.en.When;
 import uk.gov.dhsc.htbhf.page.DoYouHaveChildrenPage;
-import uk.gov.dhsc.htbhf.page.PageName;
 
 /**
  * Contains steps definitions for the Do You Have Children page.
@@ -43,11 +42,6 @@ public class DoYouHaveChildrenSteps extends CommonSteps {
                 doYouHaveChildrenPage.getFieldErrorId(),
                 doYouHaveChildrenPage.getErrorLinkCss(),
                 "Select yes if you have children who are under 4 years old");
-    }
-
-    @Then("^The back link points to the Do you have children under four years old page")
-    public void backLinkPointsToDoYouHaveChildren() {
-        assertBackLinkPointsToPage(PageName.DO_YOU_HAVE_CHILDREN);
     }
 
 }

--- a/src/test/java/uk/gov/dhsc/htbhf/steps/GenericSteps.java
+++ b/src/test/java/uk/gov/dhsc/htbhf/steps/GenericSteps.java
@@ -3,6 +3,7 @@ package uk.gov.dhsc.htbhf.steps;
 import io.cucumber.java.en.Then;
 import io.cucumber.java.en.When;
 import uk.gov.dhsc.htbhf.page.GenericPage;
+import uk.gov.dhsc.htbhf.page.PageName;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -44,6 +45,12 @@ public class GenericSteps extends CommonSteps {
     public void betaBannerHasCorrectLink() {
         String feedbackUrl = getPages().getGenericPage().getBetaBannerFeedbackLinkHref();
         assertThat(feedbackUrl).isEqualTo("https://www.smartsurvey.co.uk/s/apply-for-healthy-start-feedback/");
+    }
+
+    @Then("^the back link points to the (.*) page")
+    public void verifyBackLink(String pageNameString) {
+        PageName pageName = PageName.toPageName(pageNameString);
+        assertBackLinkPointsToPage(pageName);
     }
 
 }

--- a/src/test/java/uk/gov/dhsc/htbhf/steps/PrivacyNoticeSteps.java
+++ b/src/test/java/uk/gov/dhsc/htbhf/steps/PrivacyNoticeSteps.java
@@ -1,15 +1,8 @@
 package uk.gov.dhsc.htbhf.steps;
 
-import io.cucumber.java.en.Then;
-import uk.gov.dhsc.htbhf.page.PageName;
-
 /**
  * Steps for the privacy notice page.
  */
 public class PrivacyNoticeSteps extends CommonSteps {
 
-    @Then("the back link on the page links to the do you live in Scotland page")
-    public void assertBackLinkCorrect() {
-        assertBackLinkPointsToPage(PageName.SCOTLAND);
-    }
 }

--- a/src/test/resources/features/acceptance/check-answers.feature
+++ b/src/test/resources/features/acceptance/check-answers.feature
@@ -43,4 +43,4 @@ Feature: Check answers
 
   Scenario: Clicking on the back link takes me to the last navigable page
     Given I have entered my details up to the check answers page
-    Then The back link on the check answers page links to the email address page
+    Then the back link points to the email address page

--- a/src/test/resources/features/acceptance/child-date-of-birth.feature
+++ b/src/test/resources/features/acceptance/child-date-of-birth.feature
@@ -9,7 +9,7 @@ Feature: Enter your children’s dates of birth
   Scenario: Children’s dates of birth is navigable via the back button if I’ve said I have children
     Given I submit the details of my child who is under four years old
     When I am shown the are you pregnant page
-    Then The back link points to the Enter your children’s dates of birth page
+    Then the back link points to the enter your childrens dates of birth page
 
   Scenario: Enter one child's date of birth
     Given I enter the details of my child who is under four years old

--- a/src/test/resources/features/acceptance/do-you-have-children.feature
+++ b/src/test/resources/features/acceptance/do-you-have-children.feature
@@ -27,4 +27,4 @@ Feature: Do you have children under four years old?
   Scenario: Children’s dates of birth is not navigable via the back button if I’ve said I have no children
     When I have said No to the do you have children under four years old question
     And I am shown the are you pregnant page
-    Then The back link points to the Do you have children under four years old page
+    Then the back link points to the do you have children under four years old page

--- a/src/test/resources/features/acceptance/general-page.feature
+++ b/src/test/resources/features/acceptance/general-page.feature
@@ -9,12 +9,12 @@ Feature: Tests for features available to all pages
   Scenario: The Privacy notice page is accessible via a link on an application page and the back link is shown
     When I click on the privacy notice link
     Then I am shown the privacy notice page
-    And the back link on the page links to the do you live in Scotland page
+    And the back link points to the do you live in Scotland page
 
   Scenario: The Cookies page is accessible via a link on an application page and the back link is shown
     When I click on the cookies link
     Then I am shown the cookies page
-    And the back link on the page links to the do you live in Scotland page
+    And the back link points to the do you live in Scotland page
 
   Scenario: The Beta banner is shown and has the correct survey link
     Then the beta banner is shown


### PR DESCRIPTION
Noticed that we had a number of steps that could be refactored into a common step, so created one in GenericSteps that we can reuse based on the PageName.