### PR TITLE
Fix issue where the session cookie can be null for iOS compatibility tests.

### DIFF
--- a/src/test/java/uk/gov/dhsc/htbhf/page/BasePage.java
+++ b/src/test/java/uk/gov/dhsc/htbhf/page/BasePage.java
@@ -146,7 +146,9 @@ public abstract class BasePage extends BaseComponent {
 
     public String getCurrentSessionId() {
         Cookie sessionCookie = getCookieByName("htbhf.sid");
-        return sessionCookie.getValue();
+        //TODO MRS 16/10/2019: This will not retrieve secure cookies (iOS devices) so won't work for compatibility tests, but is ok at the moment
+        // because the value isn't used by compatibility tests even though it is retrieved when the apply page is opened.
+        return (sessionCookie != null) ? sessionCookie.getValue() : null;
     }
 
     public Cookie getLangCookie() {


### PR DESCRIPTION
This is the cause of the compatibility test failure on iOS devices. The session id is retrieved whenever we got to the Apply page but its value isn't used in compatibility tests, only the acceptance tests, so its ok to not have it for compatibility tests and just make sure we don't have a NPE.