### PR TITLE
HTBHF-2499 update session ID checks

### DIFF
--- a/src/test/java/uk/gov/dhsc/htbhf/page/Pages.java
+++ b/src/test/java/uk/gov/dhsc/htbhf/page/Pages.java
@@ -58,6 +58,14 @@ public class Pages {
         );
     }
 
+    public BasePage getFirstPage() {
+        return getScotlandPage();
+    }
+
+    public BasePage getFirstPageNoWait() {
+        return getScotlandPageNoWait();
+    }
+
     public BasePage getAndWaitForPageByName(PageName name) {
         BasePage page = getPageByName(name);
         page.waitForPageToLoad();
@@ -121,6 +129,10 @@ public class Pages {
 
     public ScotlandPage getScotlandPage() {
         return (ScotlandPage) getAndWaitForPageByName(PageName.SCOTLAND);
+    }
+
+    public ScotlandPage getScotlandPageNoWait() {
+        return (ScotlandPage) getPageByName(PageName.SCOTLAND);
     }
 
     public InScotlandPage getInScotlandPage() {

--- a/src/test/java/uk/gov/dhsc/htbhf/steps/CommonSteps.java
+++ b/src/test/java/uk/gov/dhsc/htbhf/steps/CommonSteps.java
@@ -42,6 +42,7 @@ public class CommonSteps extends BaseSteps {
         claimValuesThreadLocal.set(claimValues);
         GuidancePage applyPage = openApplyPage();
         applyPage.clickStartButton();
+        setSessionId();
         Map<PageName, Consumer<ClaimValues>> pageActions = buildStepPageActions(claimValues);
         for (Map.Entry<PageName, Consumer<ClaimValues>> entry : pageActions.entrySet()) {
             if (pageName == entry.getKey()) {
@@ -52,10 +53,14 @@ public class CommonSteps extends BaseSteps {
         }
     }
 
+    private void setSessionId() {
+        BasePage basePage = getPages().getFirstPage();
+        sessionIdThreadLocal.set(basePage.getCurrentSessionId());
+    }
+
     protected GuidancePage openApplyPage() {
         GuidancePage applyPage = getPages().getGuidancePageNoWait(PageName.APPLY);
         applyPage.open();
-        sessionIdThreadLocal.set(applyPage.getCurrentSessionId());
         return applyPage;
     }
 

--- a/src/test/java/uk/gov/dhsc/htbhf/steps/GenericSteps.java
+++ b/src/test/java/uk/gov/dhsc/htbhf/steps/GenericSteps.java
@@ -2,6 +2,7 @@ package uk.gov.dhsc.htbhf.steps;
 
 import io.cucumber.java.en.Then;
 import io.cucumber.java.en.When;
+import org.openqa.selenium.Cookie;
 import uk.gov.dhsc.htbhf.page.BasePage;
 import uk.gov.dhsc.htbhf.page.GenericPage;
 import uk.gov.dhsc.htbhf.page.PageName;
@@ -65,6 +66,30 @@ public class GenericSteps extends CommonSteps {
     public void yesAndNoOptionsAreDisplayed(String pageNameString) {
         BasePage basePage = getPages().getPageByName(PageName.toPageName(pageNameString));
         assertYesNoOptionsAreDisplayed(basePage);
+    }
+
+    @Then("^my session has not been destroyed")
+    public void verifySessionNotDestroyed() {
+        String pageSessionId = sessionIdThreadLocal.get();
+        //Navigate to the first page of the application so we can assert the session id
+        BasePage basePage = getPages().getFirstPageNoWait();
+        basePage.open();
+        Cookie langCookie = basePage.getLangCookie();
+        assertThat(langCookie).isNotNull();
+        String newSessionId = basePage.getCurrentSessionId();
+        assertThat(pageSessionId).isEqualTo(newSessionId);
+    }
+
+    @Then("^my session has been destroyed")
+    public void verifySessionDestroyed() {
+        String pageSessionId = sessionIdThreadLocal.get();
+        //Navigate to the first page of the application so we can assert the session id
+        BasePage basePage = getPages().getFirstPageNoWait();
+        basePage.open();
+        Cookie langCookie = basePage.getLangCookie();
+        assertThat(langCookie).isNotNull();
+        String newSessionId = basePage.getCurrentSessionId();
+        assertThat(pageSessionId).isNotEqualTo(newSessionId);
     }
 
 }

--- a/src/test/java/uk/gov/dhsc/htbhf/steps/GuidanceSteps.java
+++ b/src/test/java/uk/gov/dhsc/htbhf/steps/GuidanceSteps.java
@@ -3,7 +3,6 @@ package uk.gov.dhsc.htbhf.steps;
 import io.cucumber.java.en.Given;
 import io.cucumber.java.en.Then;
 import io.cucumber.java.en.When;
-import org.openqa.selenium.Cookie;
 import org.openqa.selenium.WebElement;
 import uk.gov.dhsc.htbhf.page.GuidancePage;
 import uk.gov.dhsc.htbhf.page.PageName;
@@ -36,32 +35,6 @@ public class GuidanceSteps extends CommonSteps {
         assertGuidancePageHeadersCorrect(pageName);
         assertGuidancePageContentsCorrect();
         assertGuidancePageNavigationLinksCorrect();
-    }
-
-    @Then("^my session has not been destroyed")
-    public void verifySessionNotDestroyed() {
-        String pageSessionId = sessionIdThreadLocal.get();
-        //Navigate to another page so we can assert the session id
-        GuidancePage guidancePage = getPages().getGuidancePageNoWait(PageName.APPLY);
-        guidancePage.open();
-        Cookie langCookie = guidancePage.getLangCookie();
-        assertThat(langCookie).isNotNull();
-        String newSessionId = guidancePage.getCurrentSessionId();
-        assertThat(pageSessionId).isEqualTo(newSessionId);
-    }
-
-    // To verify that the session has been destroyed we need to navigate to a subsequent page
-    // (back to the Guidance page is sufficient) to check for a new session id
-    @Then("^my session has been destroyed")
-    public void verifySessionDestroyed() {
-        String pageSessionId = sessionIdThreadLocal.get();
-        //Navigate to another page so we can assert the session id
-        GuidancePage guidancePage = getPages().getGuidancePageNoWait(PageName.APPLY);
-        guidancePage.open();
-        Cookie langCookie = guidancePage.getLangCookie();
-        assertThat(langCookie).isNotNull();
-        String newSessionId = guidancePage.getCurrentSessionId();
-        assertThat(pageSessionId).isNotEqualTo(newSessionId);
     }
 
     // Make sure there are the correct previous and/or next links on the page


### PR DESCRIPTION
Update session ID checks to operate on the first page of the application, not the guidance page.

This preempts an update to the Web UI which will stop the guidance page refreshing the session ID in the browser.