### PR TITLE
HTBHF-2506 verify redirection to first page of application

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,7 +10,7 @@ jobs:
       BIN_DIR: ./bin
       CLAIMANT_SERVICE_URL: http://localhost:8090
       USE_UNSECURE_COOKIE: true
-      WEB_UI_BRANCH: '' # if empty, download & run the latest release of web-ui. If populated, download & run that branch
+      WEB_UI_BRANCH: 'feature/completed-redirect' # if empty, download & run the latest release of web-ui. If populated, download & run that branch
       OS_PLACES_API_KEY: os-places-key
       OS_PLACES_URI: http://localhost:8150
     steps:

--- a/src/test/java/uk/gov/dhsc/htbhf/steps/NavigationSteps.java
+++ b/src/test/java/uk/gov/dhsc/htbhf/steps/NavigationSteps.java
@@ -42,4 +42,10 @@ public class NavigationSteps extends CommonSteps {
         page.waitForPageToLoad();
     }
 
+    @Then("^I am shown the first page of the application")
+    public void verifyOnFirstPageOfApplication() {
+        BasePage page = getPages().getFirstPage();
+        page.waitForPageToLoad();
+    }
+
 }

--- a/src/test/resources/features/acceptance/navigation.feature
+++ b/src/test/resources/features/acceptance/navigation.feature
@@ -23,12 +23,12 @@ Feature: Application process navigation is controlled
   Scenario Outline: Navigation after completing application returns to start of process and clears the session
     Given I have completed my application
     When I navigate to the <page> page
-    Then I am shown the How it works page
+    Then I am shown the first page of the application
     Examples:
-      | page                    |
-      | enter name              |
-      | do you live in Scotland |
-      | I live in Scotland      |
+      | page                            |
+      | enter name                      |
+      | enter national insurance number |
+      | I live in Scotland              |
 
   Scenario Outline: Navigation is not allowed past the current page in the flow
     Given I have entered my details up to the <application page> page


### PR DESCRIPTION
Verify redirection to first page of application after a user has completed an application.

This removes the requirement for the guidance pages to have knowledge of the application flow control and is a requirement of implementing multiple user journeys.