### PR TITLE
HTBHF-2694 Make sure tests run in strict mode otherwise undefined steps…

### DIFF
--- a/src/test/java/uk/gov/dhsc/htbhf/RunAcceptanceTests.java
+++ b/src/test/java/uk/gov/dhsc/htbhf/RunAcceptanceTests.java
@@ -6,7 +6,8 @@ import org.junit.runner.RunWith;
 
 @RunWith(Cucumber.class)
 @CucumberOptions(plugin = "pretty",
-        features = "src/test/resources/features"
+        features = "src/test/resources/features",
+        strict = true
 )
 public class RunAcceptanceTests {
 

--- a/src/test/java/uk/gov/dhsc/htbhf/RunCompatibilityTests.java
+++ b/src/test/java/uk/gov/dhsc/htbhf/RunCompatibilityTests.java
@@ -12,7 +12,8 @@ import org.junit.runner.RunWith;
  */
 @RunWith(Cucumber.class)
 @CucumberOptions(plugin = "pretty",
-        features = "src/test/resources/features/compatibility"
+        features = "src/test/resources/features/compatibility",
+        strict = true
 )
 public class RunCompatibilityTests {
 

--- a/src/test/resources/features/acceptance/decision.feature
+++ b/src/test/resources/features/acceptance/decision.feature
@@ -8,6 +8,6 @@ Feature: Confirm application
     Given I am on the first page of the application
     When I submit an application with valid details
     Then I am shown the decision page
-    And all page content is present on the confirm details page
+    And all page content is present on the decision details page
     And my entitlement is 12.40 per week with a first payment of 49.60
     And my claim is sent to the back end


### PR DESCRIPTION
…will not fail the build, plus fix undefined step.

Apparently the default is that tests are not strict so undefined steps will not fail the test, they will be ignored. This was hiding a small bug in the decision page verification step not being correctly referenced in the feature file.