### PR TITLE
HTBHF-1942 Modify how decision page is loaded so that we can specify the title to wait for.

### DIFF
--- a/src/test/java/uk/gov/dhsc/htbhf/page/BasePage.java
+++ b/src/test/java/uk/gov/dhsc/htbhf/page/BasePage.java
@@ -56,7 +56,11 @@ public abstract class BasePage extends BaseComponent {
     }
 
     public void waitForPageToLoad() {
-        wait.until(ExpectedConditions.titleIs(getPageTitle()));
+        waitForPageToLoad(getPageTitle());
+    }
+
+    public void waitForPageToLoad(String title) {
+        wait.until(ExpectedConditions.titleIs(title));
     }
 
     public List<WebElement> getRadioButtons() {

--- a/src/test/java/uk/gov/dhsc/htbhf/page/DecisionPage.java
+++ b/src/test/java/uk/gov/dhsc/htbhf/page/DecisionPage.java
@@ -11,6 +11,9 @@ public class DecisionPage extends BasePage {
 
     private static final String PANEL_TITLE_CLASS = "govuk-panel__title";
     private static final String PANEL_BODY_CLASS = "govuk-panel__body";
+    public static final String APPLICATION_SUCCESSFUL_TITLE = "GOV.UK - Application successful";
+    public static final String APPLICATION_UNSUCCESSFUL_TITLE = "GOV.UK - Application unsuccessful";
+    public static final String APPLICATION_PENDING_TITLE = "GOV.UK - We’ll let you know";
 
     public DecisionPage(WebDriver webDriver, String baseUrl, WebDriverWait wait) {
         super(webDriver, baseUrl, wait);
@@ -28,7 +31,7 @@ public class DecisionPage extends BasePage {
 
     @Override
     String getPageTitle() {
-        return "GOV.UK - Application successful";
+        return APPLICATION_SUCCESSFUL_TITLE;
     }
 
     public String getPanelTitleText() {

--- a/src/test/java/uk/gov/dhsc/htbhf/page/Pages.java
+++ b/src/test/java/uk/gov/dhsc/htbhf/page/Pages.java
@@ -71,6 +71,12 @@ public class Pages {
         return page;
     }
 
+    public BasePage getAndWaitForPageByNameWithTitle(PageName name, String pageTitle) {
+        BasePage page = getPageByName(name);
+        page.waitForPageToLoad(pageTitle);
+        return page;
+    }
+
     public BasePage getPageByName(PageName name) {
         return pages.stream()
                 .filter(basePage -> basePage.getPageName().equals(name))
@@ -146,8 +152,16 @@ public class Pages {
         return (TermsAndConditionsPage) getPageByName(PageName.TERMS_AND_CONDITIONS);
     }
 
-    public DecisionPage getDecisionPage() {
-        return (DecisionPage) getAndWaitForPageByName(PageName.DECISION);
+    public DecisionPage getSuccessfulDecisionPage() {
+        return (DecisionPage) getAndWaitForPageByNameWithTitle(PageName.DECISION, DecisionPage.APPLICATION_SUCCESSFUL_TITLE);
+    }
+
+    public DecisionPage getUnsuccessfulDecisionPage() {
+        return (DecisionPage) getAndWaitForPageByNameWithTitle(PageName.DECISION, DecisionPage.APPLICATION_UNSUCCESSFUL_TITLE);
+    }
+
+    public DecisionPage getPendingDecisionPage() {
+        return (DecisionPage) getAndWaitForPageByNameWithTitle(PageName.DECISION, DecisionPage.APPLICATION_PENDING_TITLE);
     }
 
     public DecisionPage getDecisionPageNoWait() {

--- a/src/test/java/uk/gov/dhsc/htbhf/steps/DecisionSteps.java
+++ b/src/test/java/uk/gov/dhsc/htbhf/steps/DecisionSteps.java
@@ -15,7 +15,7 @@ public class DecisionSteps extends CommonSteps {
     @Then("^I am shown a successful decision page|" +
             "all page content is present on the decision details page")
     public void iAmShownASuccessfulDecisionPage() {
-        DecisionPage decisionPage = getPages().getDecisionPage();
+        DecisionPage decisionPage = getPages().getSuccessfulDecisionPage();
         assertThat(decisionPage.getH2Text())
                 .as("expected decision page H2 text to be correct")
                 .isEqualTo("What happens next");

--- a/src/test/java/uk/gov/dhsc/htbhf/steps/NavigationSteps.java
+++ b/src/test/java/uk/gov/dhsc/htbhf/steps/NavigationSteps.java
@@ -27,7 +27,7 @@ public class NavigationSteps extends CommonSteps {
     public void givenIHaveCompletedMyApplication() {
         enterDetailsUpToPage(CHECK_ANSWERS);
         acceptTermsAndConditionsAndSubmitApplication();
-        getPages().getDecisionPage();
+        getPages().getSuccessfulDecisionPage();
     }
 
     @When("^I navigate to the (.*) page")


### PR DESCRIPTION
 - Add the ability to specify a page title when waiting for a page to load so that we can have 3 different titles for the decision page without having 3 different page objects.
 - The default title that is waited for when waiting for a decision page is the successful page
 - If you want to wait for a different title, there are specific methods on `Pages` that can be used to wait for that different title.
 - New ATs have yet to be created so the new methods aren't used yet.

