### PR TITLE
NO-JIRA Add extra resilience and logging to the finalise method in Hooks.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,7 +10,7 @@ jobs:
       BIN_DIR: ./bin
       CLAIMANT_SERVICE_URL: http://localhost:8090
       USE_UNSECURE_COOKIE: true
-      WEB_UI_BRANCH: 'feature/decision-refactor' # if empty, download & run the latest release of web-ui. If populated, download & run that branch
+      WEB_UI_BRANCH: '' # if empty, download & run the latest release of web-ui. If populated, download & run that branch
       OS_PLACES_API_KEY: os-places-key
       OS_PLACES_URI: http://localhost:8150
     steps:

--- a/src/test/java/uk/gov/dhsc/htbhf/steps/Hooks.java
+++ b/src/test/java/uk/gov/dhsc/htbhf/steps/Hooks.java
@@ -3,9 +3,12 @@ package uk.gov.dhsc.htbhf.steps;
 import io.cucumber.core.api.Scenario;
 import io.cucumber.java.After;
 import io.cucumber.java.Before;
+import lombok.extern.slf4j.Slf4j;
 import org.openqa.selenium.remote.RemoteWebDriver;
+import org.openqa.selenium.remote.SessionId;
 import uk.gov.dhsc.htbhf.TestResult;
 
+@Slf4j
 public class Hooks extends BaseSteps {
 
     private static ThreadLocal<String> sessionIdThreadLocal = new ThreadLocal<>();
@@ -35,6 +38,8 @@ public class Hooks extends BaseSteps {
                 testResultHandler.handleResults(sessionDetails, sessionId);
             }
             wireMockManager.resetWireMockStubs();
+        } catch (Exception e) {
+            log.error("Unexpected Exception caught finalising scenario: " + scenario.getName(), e);
         } finally {
             webDriverWrapper.quitDriver();
         }
@@ -46,6 +51,7 @@ public class Hooks extends BaseSteps {
 
     private String getSessionId() {
         RemoteWebDriver remoteWebDriver = (RemoteWebDriver) getWebDriver();
-        return remoteWebDriver.getSessionId().toString();
+        SessionId sessionId = remoteWebDriver.getSessionId();
+        return (sessionId != null) ? sessionId.toString() : "Not available";
     }
 }


### PR DESCRIPTION
In response to the compatibility test failure this morning, this will:

 - Stop a NPE being thrown from that point at that point, "Not available" will be used in that case.
 - Any Exception thrown in the @AfterTest method will now be logged out with an associated scenario name.