### PR TITLE
AFHS-546 BasePage loads page using path instead of title

### DIFF
--- a/src/test/java/uk/gov/dhsc/htbhf/page/BasePage.java
+++ b/src/test/java/uk/gov/dhsc/htbhf/page/BasePage.java
@@ -56,10 +56,18 @@ public abstract class BasePage extends BaseComponent {
     }
 
     public void waitForPageToLoad() {
-        waitForPageToLoad(getPageTitle());
+        if (getPath() == null) {
+            waitForPageToLoadWithTitle(getPageTitle());
+        } else {
+            waitForPageToLoadWithPath(getPath());
+        }
     }
 
-    public void waitForPageToLoad(String title) {
+    public void waitForPageToLoadWithPath(String path) {
+        wait.until(ExpectedConditions.urlToBe(baseUrl + path));
+    }
+
+    public void waitForPageToLoadWithTitle(String title) {
         wait.until(ExpectedConditions.titleIs(title));
     }
 

--- a/src/test/java/uk/gov/dhsc/htbhf/page/Pages.java
+++ b/src/test/java/uk/gov/dhsc/htbhf/page/Pages.java
@@ -72,7 +72,7 @@ public class Pages {
 
     public BasePage getAndWaitForPageByNameWithTitle(PageName name, String pageTitle) {
         BasePage page = getPageByName(name);
-        page.waitForPageToLoad(pageTitle);
+        page.waitForPageToLoadWithTitle(pageTitle);
         return page;
     }
 
@@ -105,6 +105,10 @@ public class Pages {
 
     public ManualAddressPage getManualAddressPage() {
         return (ManualAddressPage) getAndWaitForPageByName(PageName.MANUAL_ADDRESS);
+    }
+
+    public ManualAddressPage getManualAddressPageNoWait() {
+        return (ManualAddressPage) getPageByName(PageName.MANUAL_ADDRESS);
     }
 
     public NationalInsuranceNumberPage getNationalInsuranceNumberPage() {
@@ -181,6 +185,10 @@ public class Pages {
 
     public PostcodePage getPostcodePage() {
         return (PostcodePage) getAndWaitForPageByName(PageName.POSTCODE);
+    }
+
+    public PostcodePage getPostcodePageNoWait() {
+        return (PostcodePage) getPageByName(PageName.POSTCODE);
     }
 
     public SelectAddressPage getSelectAddressPage() {

--- a/src/test/java/uk/gov/dhsc/htbhf/steps/AddressLookupSteps.java
+++ b/src/test/java/uk/gov/dhsc/htbhf/steps/AddressLookupSteps.java
@@ -102,7 +102,7 @@ public class AddressLookupSteps extends CommonSteps {
     @Then("^I am shown a link to change my postcode")
     public void changePostcodeLinkIsShown() {
         String changePostcodeLinkHref = getPages().getSelectAddressPage().getChangePostcodeLinkHref();
-        assertThat(changePostcodeLinkHref).isEqualTo(getPages().getPostcodePage().getFullPath());
+        assertThat(changePostcodeLinkHref).isEqualTo(getPages().getPostcodePageNoWait().getFullPath());
     }
 
     @Then("^I am shown a button to enter my address manually")
@@ -114,7 +114,7 @@ public class AddressLookupSteps extends CommonSteps {
     @Then("^I am shown an address not listed link")
     public void addressNotListedLinkShown() {
         String addressNotListedLinkHref = getPages().getSelectAddressPage().getAddressNotListedLinkHref();
-        assertThat(addressNotListedLinkHref).isEqualTo(getPages().getManualAddressPage().getFullPath());
+        assertThat(addressNotListedLinkHref).isEqualTo(getPages().getManualAddressPageNoWait().getFullPath());
     }
 
     @Then("^I am shown a continue button")
@@ -123,7 +123,7 @@ public class AddressLookupSteps extends CommonSteps {
         assertThat(buttonText).isEqualTo("Continue");
     }
 
-    @Then("^I am informed that the postcode is in the wrong format")
+    @Then("^I am informed that the postcode is in the wrong format on the address lookup page")
     public void assertPostcodeInWrongFormat() {
         assertPostcodeErrorPresent("Enter a correct postcode, like AA1 1AA");
     }
@@ -135,7 +135,7 @@ public class AddressLookupSteps extends CommonSteps {
         assertThat(inputValue).isEqualTo(postcode);
     }
 
-    @Then("^I am informed that you can only apply if I live in England, Wales or Northern Ireland")
+    @Then("^I am informed that you can only apply if you live in England, Wales or Northern Ireland on the postcode page")
     public void assertPostcodeNotInEnglandWalesOrNorthernIreland() {
         assertPostcodeErrorPresent("You can only apply if you live in England, Wales or Northern Ireland");
     }
@@ -154,7 +154,7 @@ public class AddressLookupSteps extends CommonSteps {
     @Then("^I am shown a link to enter my address manually")
     public void manualAddressLinkIsShown() {
         String manualAddressLink = getPages().getSelectAddressPage().getManualAddressLinkHref();
-        assertThat(manualAddressLink).isEqualTo(getPages().getManualAddressPage().getFullPath());
+        assertThat(manualAddressLink).isEqualTo(getPages().getManualAddressPageNoWait().getFullPath());
     }
 
     private void assertPostcodeErrorPresent(String expectedErrorMessage) {

--- a/src/test/java/uk/gov/dhsc/htbhf/steps/ManualAddressSteps.java
+++ b/src/test/java/uk/gov/dhsc/htbhf/steps/ManualAddressSteps.java
@@ -120,6 +120,25 @@ public class ManualAddressSteps extends CommonSteps {
         assertTownOrCityErrorFieldAndLink(manualAddressPage, "Enter a town or city");
     }
 
+    @Then("^I am informed that you can only apply if you live in England, Wales or Northern Ireland on the manual address page")
+    public void assertPostcodeNotInEnglandWalesOrNorthernIreland() {
+        assertPostcodeErrorPresent("You can only apply if you live in England, Wales or Northern Ireland");
+    }
+
+    @Then("^I am informed that the postcode is in the wrong format on the manual address page")
+    public void assertPostcodeInWrongFormat() {
+        assertPostcodeErrorPresent("Enter a correct postcode, like AA1 1AA");
+    }
+
+    private void assertPostcodeErrorPresent(String expectedErrorMessage) {
+        ManualAddressPage manualAddressPage = getPages().getManualAddressPage();
+        assertErrorHeaderTextPresent(manualAddressPage);
+        assertFieldErrorAndLinkTextPresentAndCorrect(manualAddressPage,
+                manualAddressPage.getPostcodeInputErrorId(),
+                manualAddressPage.getPostcodeInputErrorLinkCss(),
+                expectedErrorMessage);
+    }
+
     private void assertAddressLine1ErrorFieldAndLink(ManualAddressPage manualAddressPage, String expectedErrorMessage) {
         assertFieldErrorAndLinkTextPresentAndCorrect(manualAddressPage,
                 manualAddressPage.getLine1InputErrorId(),

--- a/src/test/resources/features/acceptance/address-lookup.feature
+++ b/src/test/resources/features/acceptance/address-lookup.feature
@@ -12,6 +12,12 @@ Feature: Select address
     And I am shown a link to change my postcode
     And I am shown a button to enter my address manually
 
+  Scenario: Clicking the 'Enter address manually' button when the postcode was not found redirects to the manual address page
+    Given I have entered my details up to the postcode page
+    When I enter a postcode that returns no search results
+    And I click continue
+    Then I am shown the manual address page
+
   Scenario: Entering a postcode shows a list of matching addresses
     Given I have entered my details up to the postcode page
     When I enter a postcode that returns search results
@@ -53,7 +59,7 @@ Feature: Select address
   Scenario Outline: Enter an invalid postcode on the postcode lookup page
     Given I have entered my details up to the postcode page
     When I enter <postcode> as my postcode
-    Then I am informed that the postcode is in the wrong format
+    Then I am informed that the postcode is in the wrong format on the address lookup page
     And I see the postcode: <postcode> in the same format I entered it in
 
     Examples:
@@ -67,7 +73,7 @@ Feature: Select address
   Scenario Outline: Entering a postcode from the Channel Islands or Isle of Man shows an error
     Given I have entered my details up to the postcode page
     When I enter <postcode> as my postcode
-    Then I am informed that you can only apply if I live in England, Wales or Northern Ireland
+    Then I am informed that you can only apply if you live in England, Wales or Northern Ireland on the postcode page
     And I see the postcode: <postcode> in the same format I entered it in
 
     Examples:

--- a/src/test/resources/features/acceptance/manual-address.feature
+++ b/src/test/resources/features/acceptance/manual-address.feature
@@ -26,7 +26,7 @@ Feature: Address
 
   Scenario Outline: Enter an address with an invalid postcode
     When I enter an address with postcode <postcode>
-    Then I am informed that the postcode is in the wrong format
+    Then I am informed that the postcode is in the wrong format on the manual address page
 
     Examples:
       | postcode |
@@ -36,7 +36,7 @@ Feature: Address
 
   Scenario Outline: Entering a postcode from the Channel Islands or Isle of Man shows an error
     When I enter an address with postcode <postcode>
-    Then I am informed that you can only apply if I live in England, Wales or Northern Ireland
+    Then I am informed that you can only apply if you live in England, Wales or Northern Ireland on the manual address page
 
     Examples:
       | postcode |

--- a/src/test/resources/features/acceptance/national-insurance-number.feature
+++ b/src/test/resources/features/acceptance/national-insurance-number.feature
@@ -8,7 +8,7 @@ Feature: Enter National Insurance number
 
   Scenario: Enter in a valid national insurance number
     When I enter a valid national insurance number
-    Then I am shown the manual address page
+    Then I am shown the postcode page
 
   Scenario: Do not enter in a "national insurance number"
     When I do not enter a national insurance number


### PR DESCRIPTION
Updated the BasePage class to use the page's path rather than title to load the page.
Doing this revealed a few test errors with around address lookup. As all of the address lookup pages have the same title, some steps were incorrectly getting the wrong page.